### PR TITLE
chore: configure Renovate for weekly grouped PRs + immediate security alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,40 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ]
+    "config:recommended",
+    "group:allNonMajor",
+    ":dependencyDashboard"
+  ],
+  "schedule": ["before 9am on Monday"],
+  "timezone": "America/Denver",
+  "prConcurrentLimit": 3,
+  "packageRules": [
+    {
+      "description": "Group all non-security dependency updates into a single weekly PR",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "all non-major dependencies",
+      "schedule": ["before 9am on Monday"]
+    },
+    {
+      "description": "Group major updates separately (weekly)",
+      "matchUpdateTypes": ["major"],
+      "groupName": "major updates",
+      "schedule": ["before 9am on Monday"]
+    },
+    {
+      "description": "Security/vulnerability updates: create PRs immediately",
+      "matchCategories": ["security"],
+      "groupName": null,
+      "schedule": ["at any time"],
+      "prPriority": 10,
+      "labels": ["security", "zero-day"],
+      "automerge": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["at any time"],
+    "labels": ["security", "zero-day"],
+    "prPriority": 10
+  }
 }


### PR DESCRIPTION
## Summary
- Groups all non-security dependency updates into 1-2 weekly PRs (Monday mornings, Mountain time)
- Keeps security/vulnerability PRs immediate and individually created with `security` + `zero-day` labels
- Adds dependency dashboard issue for visibility
- Limits concurrent PRs to 3

## Why
Renovate's default `config:recommended` preset creates an individual PR per dependency update, flooding the repo with noise. This change reduces PR volume while preserving fast response to security vulnerabilities.

## After merging
The 9 currently open Renovate PRs should be closed — Renovate will recreate grouped ones on the next Monday schedule.