### PR TITLE
fix: upgrade vite to v8 and plugin-react to v6 (CVE-2026-39365)

### DIFF
--- a/applications/sentinel/frontend/package.json
+++ b/applications/sentinel/frontend/package.json
@@ -27,7 +27,7 @@
     "@types/react-youtube": "^7.6.2",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",
-    "@vitejs/plugin-react": "^4.2.0",
+    "@vitejs/plugin-react": "^6.0.0",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.0.1",
@@ -36,6 +36,6 @@
     "prettier": "^3.7.4",
     "typescript": "^5.2.2",
     "typescript-eslint": "^8.50.0",
-    "vite": "^5.0.0"
+    "vite": "^8.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Upgrades `vite` from `^5.0.0` to `^8.0.0` to remediate **CVE-2026-39365** (path traversal in `.map` file handling)
- Upgrades `@vitejs/plugin-react` from `^4.2.0` to `^6.0.0` (required for Vite 8 compatibility)

## CVE Details
**CVE-2026-39365** — Any `.map` files outside the project root can be returned to the browser when the Vite dev server is exposed to the network via `--host` or `server.host`.

## Impact Assessment
The Sentinel frontend uses a vanilla Vite config (React plugin + dev proxy only). No custom Rollup options, Sass, Babel plugins, or esbuild config — so the v5→v8 migration requires no additional config changes.

## Test Plan
- [ ] `npm install` resolves cleanly
- [ ] `npm run build` succeeds
- [ ] `npm run dev` starts without errors
- [ ] Verify dev proxy to `/api` still works

Supersedes #22