### PR TITLE
Fix restore logic to not skip if source bucket is in same project

### DIFF
--- a/applications/foldrun/foldrun-agent/foldrun_app/core/download.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/core/download.py
@@ -353,7 +353,7 @@ def submit_downloads(
             )
             continue
 
-        if existing.get(db_name):
+        if not source_bucket and existing.get(db_name):
             nfs_path = databases_config[db_name]["nfs_path"]
             results.append(
                 {


### PR DESCRIPTION
Modified submit_downloads in foldrun_app/core/download.py to proceed with the restore operation if a source_bucket is specified, preventing false skips.
