### PR TITLE
fix(deps): upgrade sentinel frontend to React 19, MUI 9, TS 6

### DIFF
--- a/applications/sentinel/frontend/package.json
+++ b/applications/sentinel/frontend/package.json
@@ -14,16 +14,16 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^5.14.18",
-    "@mui/material": "^5.14.18",
+    "@mui/icons-material": "^9.0.0",
+    "@mui/material": "^9.0.0",
     "axios": "^1.6.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-youtube": "^10.1.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.37",
-    "@types/react-dom": "^18.2.15",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "@types/react-youtube": "^7.6.2",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",
@@ -32,9 +32,9 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.26",
-    "globals": "^15.15.0",
+    "globals": "^17.0.0",
     "prettier": "^3.7.4",
-    "typescript": "^5.2.2",
+    "typescript": "^6.0.0",
     "typescript-eslint": "^8.50.0",
     "vite": "^5.0.0"
   }


### PR DESCRIPTION
## Summary
- Upgrades sentinel frontend major dependencies: React 18 to 19, MUI 5 to 9, TypeScript 5 to 6, globals 15 to 17
- Intentionally excludes ESLint 9 to 10 from Renovate PR #26 because eslint-plugin-react-hooks 7.x does not support ESLint 10 yet (peer dep max is ^9)
- Verified: TypeScript compiles cleanly, Vite builds successfully, no deprecated React APIs in use (already on createRoot, modern hooks only)

## Context
Supersedes the non-ESLint portions of #26. ESLint 10 upgrade can follow once eslint-plugin-react-hooks publishes a compatible stable release.

## Test plan
- [x] tsc --noEmit passes
- [x] vite build passes
- [ ] Manual smoke test of the frontend