### PR TITLE
MMCIF PDB path fix

### DIFF
--- a/applications/foldrun/foldrun-agent/databases.yaml
+++ b/applications/foldrun/foldrun-agent/databases.yaml
@@ -119,9 +119,9 @@ databases:
         echo "/mnt/scratch not found, falling back to NFS for scratch..."
         mkdir -p {dest}/scratch && ln -s {dest}/scratch /mnt/scratch
       fi
-      mkdir -p /mnt/scratch/raw /mnt/scratch/mmcif_files
+      mkdir -p /mnt/scratch/raw /mnt/scratch/pdb_mmcif/mmcif_files
       mkdir -p {dest}/mmcif_files
-      export GCS_SYNC_SOURCE=/mnt/scratch/mmcif_files/
+      export GCS_SYNC_SOURCE=/mnt/scratch/pdb_mmcif/
 
       # 2. Sync from RCSB to SSD (Background)
       echo "Syncing structures from RCSB (in background)..."
@@ -136,25 +136,26 @@ databases:
         # Decompress finished files (not starting with .)
         find /mnt/scratch/raw -name '[!.]*.cif.gz' -exec unpigz -f {} + 2>/dev/null || true
         # Move to flat directory
-        find /mnt/scratch/raw -name '[!.]*.cif' -exec mv -t /mnt/scratch/mmcif_files/ {} + 2>/dev/null || true
+        find /mnt/scratch/raw -name '[!.]*.cif' -exec mv -t /mnt/scratch/pdb_mmcif/mmcif_files/ {} + 2>/dev/null || true
         # Incremental sync to NFS
-        rsync -ah /mnt/scratch/mmcif_files/ {dest}/mmcif_files/ 2>/dev/null || true
+        rsync -ah /mnt/scratch/pdb_mmcif/mmcif_files/ {dest}/mmcif_files/ 2>/dev/null || true
         sleep 30
       done
 
       # 4. Final Cleanup Pass
       echo "Finalizing decompression and move..."
       find /mnt/scratch/raw -name '*.cif.gz' -exec unpigz -f {} +
-      find /mnt/scratch/raw -name '*.cif' -exec mv -t /mnt/scratch/mmcif_files/ {} +
+      find /mnt/scratch/raw -name '*.cif' -exec mv -t /mnt/scratch/pdb_mmcif/mmcif_files/ {} +
       rm -rf /mnt/scratch/raw
 
       # 5. Final high-bandwidth Sync to NFS
       echo "Syncing final files to NFS..."
-      rsync -ah --info=progress2 /mnt/scratch/mmcif_files/ {dest}/mmcif_files/
+      rsync -ah --info=progress2 /mnt/scratch/pdb_mmcif/mmcif_files/ {dest}/mmcif_files/
       
       # 6. Additional metadata
       echo "Downloading obsolete metadata..."
       aria2c --continue=true 'https://files.wwpdb.org/pub/pdb/data/status/obsolete.dat' --dir={dest}
+      cp {dest}/obsolete.dat /mnt/scratch/pdb_mmcif/obsolete.dat
 
   # ===========================================================================
   # AlphaFold2 only


### PR DESCRIPTION
Resolve issue where NFS structure for mmcif was incorrect when restoring from GCS

