### PR TITLE
Set Openfold 3 container image to 0.3.1 instead of stable

### DIFF
--- a/applications/foldrun/src/openfold3-components/Dockerfile
+++ b/applications/foldrun/src/openfold3-components/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfoldconsortium/openfold3:stable
+FROM openfoldconsortium/openfold3:0.3.1
 
 # No GCS libraries needed — all I/O via NFS mounts and KFP artifacts,
 # consistent with the AF2 container.


### PR DESCRIPTION
Stable tag was moved to 0.4 which introduced breaking change in pipeline execution