### PR TITLE
test(foldrun): add AF2 unit test suite to match OF3 and Boltz-2 coverage

### DIFF
--- a/applications/foldrun/foldrun-agent/tests/unit/models/af2/test_af2_compilation.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/models/af2/test_af2_compilation.py
@@ -1,0 +1,204 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AF2 pipeline compilation — load, compile to YAML, verify DAG."""
+
+import os
+import sys
+import tempfile
+import yaml
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_env():
+    env = {
+        "GCP_PROJECT_ID": "test-project",
+        "GCP_REGION": "us-central1",
+        "GCS_BUCKET_NAME": "test-bucket",
+        "FILESTORE_ID": "test-nfs",
+        "ALPHAFOLD_COMPONENTS_IMAGE": "af2-image:latest",
+        "BOLTZ2_COMPONENTS_IMAGE": "boltz2-image:stable",
+        "OPENFOLD3_COMPONENTS_IMAGE": "of3-image:latest",
+        "NFS_SERVER": "10.1.0.2",
+        "NFS_PATH": "/datasets",
+        "NFS_MOUNT_POINT": "/mnt/nfs/foldrun",
+        "NETWORK": "projects/123/global/networks/test-net",
+        "DATA_PIPELINE_MACHINE_TYPE": "c2-standard-16",
+        "PREDICT_MACHINE_TYPE": "a2-highgpu-1g",
+        "PREDICT_ACCELERATOR_TYPE": "NVIDIA_TESLA_A100",
+        "PREDICT_ACCELERATOR_COUNT": "1",
+        "RELAX_MACHINE_TYPE": "a2-highgpu-1g",
+        "RELAX_ACCELERATOR_TYPE": "NVIDIA_TESLA_A100",
+        "RELAX_ACCELERATOR_COUNT": "1",
+        "PARALLELISM": "5",
+        "DWS_MAX_WAIT_HOURS": "168",
+        "MODEL_PARAMS_GCS_LOCATION": "gs://test-bucket/alphafold2",
+        "GOOGLE_CLOUD_PROJECT": "test-project",
+        "GOOGLE_CLOUD_LOCATION": "global",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        yield
+
+
+def _clear_config_cache():
+    for key in list(sys.modules.keys()):
+        if key == "config" or "pipeline.pipelines" in key:
+            del sys.modules[key]
+
+
+class TestAF2PipelineCompilation:
+    """Compile the AF2 pipeline to YAML and verify the result."""
+
+    def test_monomer_pipeline_compiles(self):
+        """Standard jackhmmer monomer pipeline compiles without error."""
+        _clear_config_cache()
+        from foldrun_app.models.af2.utils.pipeline_utils import load_vertex_pipeline
+        from kfp import compiler
+
+        pipeline = load_vertex_pipeline(enable_flex_start=False, msa_method="jackhmmer")
+        out = os.path.join(tempfile.gettempdir(), "af2_mono_test.yaml")
+        compiler.Compiler().compile(pipeline_func=pipeline, package_path=out)
+
+        with open(out) as f:
+            spec = yaml.safe_load(f)
+        assert "pipelineSpec" in spec or "components" in spec
+        os.remove(out)
+
+    def test_flex_start_pipeline_compiles(self):
+        """FLEX_START pipeline compiles without error."""
+        _clear_config_cache()
+        from foldrun_app.models.af2.utils.pipeline_utils import load_vertex_pipeline
+        from kfp import compiler
+
+        pipeline = load_vertex_pipeline(enable_flex_start=True, msa_method="jackhmmer")
+        out = os.path.join(tempfile.gettempdir(), "af2_flex_test.yaml")
+        compiler.Compiler().compile(pipeline_func=pipeline, package_path=out)
+
+        with open(out) as f:
+            spec = yaml.safe_load(f)
+        assert "pipelineSpec" in spec or "components" in spec
+        os.remove(out)
+
+    def test_compiled_pipeline_contains_predict(self):
+        """Compiled YAML references a predict task."""
+        _clear_config_cache()
+        from foldrun_app.models.af2.utils.pipeline_utils import load_vertex_pipeline
+        from kfp import compiler
+
+        pipeline = load_vertex_pipeline(enable_flex_start=False)
+        out = os.path.join(tempfile.gettempdir(), "af2_check_predict.yaml")
+        compiler.Compiler().compile(pipeline_func=pipeline, package_path=out)
+
+        with open(out) as f:
+            content = f.read()
+        assert "predict" in content.lower()
+        os.remove(out)
+
+    def test_compiled_pipeline_contains_relax(self):
+        """Compiled YAML references a relax task — AF2-specific."""
+        _clear_config_cache()
+        from foldrun_app.models.af2.utils.pipeline_utils import load_vertex_pipeline
+        from kfp import compiler
+
+        pipeline = load_vertex_pipeline(enable_flex_start=False)
+        out = os.path.join(tempfile.gettempdir(), "af2_check_relax.yaml")
+        compiler.Compiler().compile(pipeline_func=pipeline, package_path=out)
+
+        with open(out) as f:
+            content = f.read()
+        assert "relax" in content.lower()
+        os.remove(out)
+
+    def test_compiled_pipeline_contains_data_pipeline(self):
+        """Compiled YAML references a data pipeline (MSA) task."""
+        _clear_config_cache()
+        from foldrun_app.models.af2.utils.pipeline_utils import load_vertex_pipeline
+        from kfp import compiler
+
+        pipeline = load_vertex_pipeline(enable_flex_start=False)
+        out = os.path.join(tempfile.gettempdir(), "af2_check_msa.yaml")
+        compiler.Compiler().compile(pipeline_func=pipeline, package_path=out)
+
+        with open(out) as f:
+            content = f.read()
+        assert "data" in content.lower() or "pipeline" in content.lower()
+        os.remove(out)
+
+    def test_compiled_pipeline_has_sequence_path_parameter(self):
+        """Compiled YAML exposes sequence_path as a required input parameter."""
+        _clear_config_cache()
+        from foldrun_app.models.af2.utils.pipeline_utils import load_vertex_pipeline
+        from kfp import compiler
+
+        pipeline = load_vertex_pipeline(enable_flex_start=False)
+        out = os.path.join(tempfile.gettempdir(), "af2_check_seqpath.yaml")
+        compiler.Compiler().compile(pipeline_func=pipeline, package_path=out)
+
+        with open(out) as f:
+            content = f.read()
+        # AF2 uses PARALLELISM as a baked-in env var, not a pipeline parameter.
+        # Verify the pipeline has sequence_path and model_preset as user-facing inputs.
+        assert "sequence_path" in content
+        assert "model_preset" in content
+        os.remove(out)
+
+
+class TestAF2ConfigModuleIsolation:
+    """Verify AF2 config module doesn't collide with OF3 or Boltz-2."""
+
+    def test_af2_then_of3_config_isolation(self):
+        """Loading AF2 pipeline then OF3 pipeline uses correct base images."""
+        _clear_config_cache()
+        from foldrun_app.models.af2.utils.pipeline_utils import load_vertex_pipeline as load_af2
+
+        af2_pipeline = load_af2(enable_flex_start=False)
+
+        from foldrun_app.models.af2.pipeline import config as af2_config
+
+        assert af2_config.ALPHAFOLD_COMPONENTS_IMAGE == "af2-image:latest"
+
+        _clear_config_cache()
+        from foldrun_app.models.of3.utils.pipeline_utils import load_vertex_pipeline as load_of3
+
+        of3_pipeline = load_of3(enable_flex_start=False)
+
+        from foldrun_app.models.of3.pipeline import config as of3_config
+
+        assert of3_config.OPENFOLD3_COMPONENTS_IMAGE == "of3-image:latest"
+
+        assert callable(af2_pipeline)
+        assert callable(of3_pipeline)
+
+    def test_af2_then_boltz2_config_isolation(self):
+        """Loading AF2 pipeline then Boltz-2 pipeline uses correct base images."""
+        _clear_config_cache()
+        from foldrun_app.models.af2.utils.pipeline_utils import load_vertex_pipeline as load_af2
+
+        load_af2(enable_flex_start=False)
+
+        from foldrun_app.models.af2.pipeline import config as af2_config
+
+        assert af2_config.ALPHAFOLD_COMPONENTS_IMAGE == "af2-image:latest"
+
+        _clear_config_cache()
+        from foldrun_app.models.boltz2.utils.pipeline_utils import load_vertex_pipeline as load_b2
+
+        load_b2(enable_flex_start=False)
+
+        from foldrun_app.models.boltz2.pipeline import config as b2_config
+
+        assert b2_config.BOLTZ2_COMPONENTS_IMAGE == "boltz2-image:stable"

--- a/applications/foldrun/foldrun-agent/tests/unit/models/af2/test_af2_config.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/models/af2/test_af2_config.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AF2 Config class."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_env():
+    env = {
+        "GCP_PROJECT_ID": "test-project",
+        "GCP_REGION": "us-central1",
+        "GCS_BUCKET_NAME": "test-bucket",
+        "FILESTORE_ID": "test-nfs",
+        "ALPHAFOLD_COMPONENTS_IMAGE": "test-af2-image:latest",
+        "AF2_VIEWER_URL": "https://viewer.example.com",
+        "AF2_PARALLELISM": "5",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        with patch("google.cloud.aiplatform.init"), patch("google.cloud.storage.Client"):
+            yield
+
+
+class TestAF2Config:
+    """Tests for AF2 Config initialization and properties."""
+
+    def test_config_loads_from_env(self):
+        from foldrun_app.models.af2.config import Config
+
+        config = Config()
+        assert config.project_id == "test-project"
+        assert config.region == "us-central1"
+        assert config.base_image == "test-af2-image:latest"
+
+    def test_config_bucket_name(self):
+        from foldrun_app.models.af2.config import Config
+
+        config = Config()
+        assert config.bucket_name == "test-bucket"
+
+    def test_config_viewer_url(self):
+        from foldrun_app.models.af2.config import Config
+
+        config = Config()
+        assert config.viewer_url == "https://viewer.example.com"
+
+    def test_config_viewer_url_defaults_to_empty(self, monkeypatch):
+        monkeypatch.delenv("AF2_VIEWER_URL", raising=False)
+        from foldrun_app.models.af2.config import Config
+
+        config = Config()
+        assert config.viewer_url == ""
+
+    def test_config_parallelism(self):
+        from foldrun_app.models.af2.config import Config
+
+        config = Config()
+        assert config.parallelism == 5
+
+    def test_config_parallelism_default(self, monkeypatch):
+        monkeypatch.delenv("AF2_PARALLELISM", raising=False)
+        from foldrun_app.models.af2.config import Config
+
+        config = Config()
+        assert config.parallelism == 5
+
+    def test_config_missing_image_raises(self, monkeypatch):
+        monkeypatch.delenv("ALPHAFOLD_COMPONENTS_IMAGE", raising=False)
+        monkeypatch.setattr("foldrun_app.core.config.load_dotenv", lambda *a, **kw: None)
+        from foldrun_app.models.af2.config import Config
+
+        with pytest.raises(ValueError, match="Missing required environment variables"):
+            Config()
+
+    def test_config_to_dict(self):
+        from foldrun_app.models.af2.config import Config
+
+        config = Config()
+        d = config.to_dict()
+        assert "base_image" in d
+        assert "viewer_url" in d
+        assert d["base_image"] == "test-af2-image:latest"
+        assert d["project_id"] == "test-project"
+
+    def test_config_supported_gpus_default(self):
+        from foldrun_app.models.af2.config import Config
+
+        config = Config()
+        # Should include at least A100 by default
+        assert "A100" in config.supported_gpus

--- a/applications/foldrun/foldrun-agent/tests/unit/models/af2/test_af2_hardware.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/models/af2/test_af2_hardware.py
@@ -1,0 +1,231 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AF2 hardware configuration and GPU tier auto-selection."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_env():
+    env = {
+        "GCP_PROJECT_ID": "test-project",
+        "GCP_REGION": "us-central1",
+        "GCS_BUCKET_NAME": "test-bucket",
+        "FILESTORE_ID": "test-nfs",
+        "ALPHAFOLD_COMPONENTS_IMAGE": "test-af2-image:latest",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        with patch("google.cloud.aiplatform.init"), patch("google.cloud.storage.Client"):
+            yield
+
+
+class TestAF2GPURecommendation:
+    """Test GPU auto-selection tiers for monomers and multimers.
+
+    After the L4 removal (fix #47), A100 is the minimum auto-selected GPU.
+    L4 can still be requested explicitly but is never auto-selected.
+    """
+
+    # --- Monomer thresholds ---
+
+    def test_monomer_small_gets_a100(self):
+        """Monomers <=1500 residues get A100 40GB."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        assert AF2Tool._recommend_gpu(100, is_multimer=False) == "A100"
+        assert AF2Tool._recommend_gpu(500, is_multimer=False) == "A100"
+        assert AF2Tool._recommend_gpu(1500, is_multimer=False) == "A100"
+
+    def test_monomer_large_gets_a100_80gb(self):
+        """Monomers >1500 residues get A100 80GB."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        assert AF2Tool._recommend_gpu(1501, is_multimer=False) == "A100_80GB"
+        assert AF2Tool._recommend_gpu(3000, is_multimer=False) == "A100_80GB"
+
+    def test_monomer_never_gets_l4_auto(self):
+        """L4 is never auto-selected for any monomer size."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        for length in [10, 100, 500, 1000, 1500]:
+            assert AF2Tool._recommend_gpu(length, is_multimer=False) != "L4"
+
+    # --- Multimer thresholds ---
+
+    def test_multimer_small_gets_a100(self):
+        """Multimers <1000 total residues get A100 40GB."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        assert AF2Tool._recommend_gpu(999, is_multimer=True) == "A100"
+        assert AF2Tool._recommend_gpu(500, is_multimer=True) == "A100"
+
+    def test_multimer_large_gets_a100_80gb(self):
+        """Multimers >=1000 total residues get A100 80GB."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        assert AF2Tool._recommend_gpu(1000, is_multimer=True) == "A100_80GB"
+        assert AF2Tool._recommend_gpu(2000, is_multimer=True) == "A100_80GB"
+
+    def test_multimer_never_gets_l4_auto(self):
+        """L4 is never auto-selected for any multimer size."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        for length in [100, 500, 999]:
+            assert AF2Tool._recommend_gpu(length, is_multimer=True) != "L4"
+
+
+class TestAF2HardwareConfig:
+    """Test hardware config dictionary generation."""
+
+    def test_auto_gpu_small_monomer(self):
+        """auto GPU for small monomer resolves to A100."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config(
+            "auto", seq_length=500, is_multimer=False
+        )
+        assert config["predict_accel"] == "NVIDIA_TESLA_A100"
+        assert config["predict_machine"] == "a2-highgpu-1g"
+
+    def test_auto_gpu_large_monomer(self):
+        """auto GPU for large monomer resolves to A100 80GB."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config(
+            "auto", seq_length=2000, is_multimer=False
+        )
+        assert config["predict_accel"] == "NVIDIA_A100_80GB"
+        assert config["predict_machine"] == "a2-ultragpu-1g"
+
+    def test_explicit_a100(self):
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("A100")
+        assert config["predict_accel"] == "NVIDIA_TESLA_A100"
+        assert config["predict_machine"] == "a2-highgpu-1g"
+
+    def test_explicit_a100_80gb(self):
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("A100_80GB")
+        assert config["predict_accel"] == "NVIDIA_A100_80GB"
+        assert config["predict_machine"] == "a2-ultragpu-1g"
+
+    def test_explicit_l4_still_works(self):
+        """Users can still request L4 explicitly, even though it's not auto-selected."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("L4")
+        assert config["predict_accel"] == "NVIDIA_L4"
+        assert config["predict_machine"] == "g2-standard-12"
+
+    def test_relax_uses_a100_when_predict_is_a100(self):
+        """A100 predict tier uses A100 for relax (not L4 — slow to provision)."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("A100")
+        assert config["relax_accel"] == "NVIDIA_TESLA_A100"
+        assert config["relax_machine"] == "a2-highgpu-1g"
+
+    def test_relax_downgraded_to_a100_when_predict_is_a100_80gb(self):
+        """A100 80GB predict downgrades relax to A100 40GB for cost savings."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("A100_80GB")
+        assert config["relax_accel"] == "NVIDIA_TESLA_A100"
+        assert config["relax_machine"] == "a2-highgpu-1g"
+
+    def test_multi_gpu_a100(self):
+        """Multi-GPU A100 selects correct multi-GPU machine type."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("A100", num_gpus=4)
+        assert config["predict_machine"] == "a2-highgpu-4g"
+        assert config["predict_count"] == 4
+
+    def test_multi_gpu_a100_80gb(self):
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("A100_80GB", num_gpus=2)
+        assert config["predict_machine"] == "a2-ultragpu-2g"
+        assert config["predict_count"] == 2
+
+    def test_data_pipeline_always_cpu(self):
+        """Data pipeline (MSA) uses CPU machine regardless of GPU tier."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        for gpu in ["L4", "A100", "A100_80GB"]:
+            config = tool._get_hardware_config(gpu)
+            assert config["data_pipeline"] == "c2-standard-16"
+
+    def test_mmseqs2_adds_gpu_dp_config(self):
+        """MMseqs2 MSA method adds GPU data pipeline config."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("A100", msa_method="mmseqs2")
+        assert config["msa_method"] == "mmseqs2"
+        assert "dp_machine" in config
+        assert "dp_accel" in config
+        assert "dp_accel_count" in config
+
+    def test_jackhmmer_no_gpu_dp_config(self):
+        """Jackhmmer MSA method does not add GPU data pipeline config."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("A100", msa_method="jackhmmer")
+        assert config["msa_method"] == "jackhmmer"
+        assert "dp_machine" not in config
+
+    def test_auto_msa_method_defaults_to_jackhmmer(self):
+        """auto msa_method resolves to jackhmmer (not mmseqs2)."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("A100", msa_method="auto")
+        assert config["msa_method"] == "jackhmmer"
+
+    def test_relax_gpu_override(self):
+        """Explicit relax_gpu_type overrides the default relax config."""
+        from foldrun_app.models.af2.base import AF2Tool
+
+        tool = AF2Tool({"name": "test", "description": "test"})
+        config = tool._get_hardware_config("A100", relax_gpu_type="L4")
+        assert config["relax_accel"] == "NVIDIA_L4"
+        assert config["relax_machine"] == "g2-standard-12"
+
+    def test_unsupported_gpu_upgrades(self):
+        """Requesting an unsupported GPU auto-upgrades along the path L4→A100→A100_80GB."""
+        from foldrun_app.models.af2.base import AF2Tool
+        from foldrun_app.models.af2.config import Config
+
+        with patch.object(Config, "supported_gpus", new_callable=lambda: property(lambda self: ["A100"])):
+            tool = AF2Tool({"name": "test", "description": "test"})
+            config = tool._get_hardware_config("L4")
+            assert config["predict_accel"] == "NVIDIA_TESLA_A100"

--- a/applications/foldrun/foldrun-agent/tests/unit/models/af2/test_af2_pipeline.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/models/af2/test_af2_pipeline.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AF2 pipeline source structure."""
+
+import os
+
+
+def _read_pipeline_source():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..", "..", "..", "..",
+        "foldrun_app", "models", "af2", "pipeline", "pipelines",
+        "alphafold_inference_pipeline.py",
+    )
+    with open(os.path.normpath(path)) as f:
+        return f.read()
+
+
+def _read_component(name: str) -> str:
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..", "..", "..", "..",
+        "foldrun_app", "models", "af2", "pipeline", "components",
+        f"{name}.py",
+    )
+    with open(os.path.normpath(path)) as f:
+        return f.read()
+
+
+class TestAF2PipelineSource:
+    """Inspect AF2 pipeline source for structural correctness."""
+
+    def test_pipeline_has_configure_step(self):
+        assert "ConfigureRunOp" in _read_pipeline_source()
+
+    def test_pipeline_has_data_pipeline_step(self):
+        assert "data_pipeline" in _read_pipeline_source()
+
+    def test_pipeline_has_predict_step(self):
+        src = _read_pipeline_source()
+        assert "PredictOp" in src or "predict" in src.lower()
+
+    def test_pipeline_has_relax_step(self):
+        """AF2 has AMBER relaxation — unlike OF3 and Boltz-2."""
+        src = _read_pipeline_source()
+        assert "RelaxOp" in src or "relax" in src.lower()
+
+    def test_pipeline_uses_parallel_for(self):
+        """Predict/relax tasks use ParallelFor for concurrent model seeds."""
+        assert "dsl.ParallelFor" in _read_pipeline_source()
+
+    def test_pipeline_has_retry_policies(self):
+        src = _read_pipeline_source()
+        assert src.count(".set_retry(") >= 2
+
+    def test_pipeline_nfs_mounts(self):
+        """AF2 uses NFS mounts for the data pipeline step.
+        Predict/relax use custom training jobs which handle NFS differently."""
+        assert _read_pipeline_source().count("nfs_mounts=") >= 1
+
+    def test_pipeline_accepts_model_preset(self):
+        """Pipeline accepts model_preset parameter (monomer/multimer)."""
+        assert "model_preset" in _read_pipeline_source()
+
+    def test_pipeline_accepts_is_run_relax(self):
+        """Pipeline accepts is_run_relax parameter to toggle AMBER."""
+        assert "is_run_relax" in _read_pipeline_source()
+
+    def test_pipeline_accepts_use_small_bfd(self):
+        """Pipeline accepts use_small_bfd for database selection."""
+        assert "use_small_bfd" in _read_pipeline_source()
+
+    def test_pipeline_flex_start_on_gpu_tasks(self):
+        """FLEX_START strategy is applied to GPU tasks (predict/relax), not CPU data pipeline."""
+        src = _read_pipeline_source()
+        assert "strategy" in src
+        assert '"STANDARD"' in src  # CPU data pipeline always STANDARD
+
+    def test_mmseqs2_path_in_pipeline(self):
+        """Pipeline has a code path for mmseqs2 GPU-accelerated MSA."""
+        src = _read_pipeline_source()
+        assert "mmseqs2" in src
+
+    def test_pipeline_parallelism_limit(self):
+        """Pipeline applies a parallelism limit to prevent GPU over-scheduling."""
+        src = _read_pipeline_source()
+        assert "PARALLELISM" in src or "parallelism" in src.lower()
+
+
+class TestAF2ComponentSources:
+    """Verify key component CLI args and structure."""
+
+    def test_predict_relax_uses_alphafold_utils(self):
+        """predict_relax delegates to the alphafold_utils module."""
+        src = _read_component("predict_relax")
+        assert "alphafold_utils" in src
+        assert "predict_relax" in src
+
+    def test_predict_relax_handles_run_relax_flag(self):
+        """predict_relax respects the is_run_relax parameter."""
+        src = _read_component("predict_relax")
+        assert "is_run_relax" in src
+        assert 'run_relax=(is_run_relax == "relax")' in src
+
+    def test_predict_relax_outputs_three_artifacts(self):
+        """predict_relax produces raw_predictions, unrelaxed_proteins, relaxed_proteins."""
+        src = _read_component("predict_relax")
+        assert "raw_predictions" in src
+        assert "unrelaxed_proteins" in src
+        assert "relaxed_proteins" in src
+
+    def test_predict_relax_sets_memory_env_vars(self):
+        """predict_relax sets TF and XLA memory flags for GPU."""
+        src = _read_component("predict_relax")
+        assert "TF_FORCE_UNIFIED_MEMORY" in src
+        assert "XLA_PYTHON_CLIENT_MEM_FRACTION" in src
+
+    def test_data_pipeline_uses_jackhmmer(self):
+        """data_pipeline component uses Jackhmmer for protein MSA."""
+        src = _read_component("data_pipeline")
+        assert "jackhmmer" in src.lower()
+
+    def test_data_pipeline_uses_hhblits(self):
+        """data_pipeline uses HHblits for BFD search."""
+        src = _read_component("data_pipeline")
+        assert "hhblits" in src.lower() or "hhsearch" in src.lower() or "bfd" in src.lower()
+
+    def test_configure_run_sets_model_preset(self):
+        """configure_run uses model_preset to select monomer vs multimer models."""
+        src = _read_component("configure_run")
+        assert "model_preset" in src
+        assert "monomer" in src
+        assert "multimer" in src
+
+    def test_version_component_exists(self):
+        """version.py component tracks AF2 component image version."""
+        src = _read_component("version")
+        assert len(src) > 0


### PR DESCRIPTION
## Summary

Adds `tests/unit/models/af2/` with 59 tests across 4 files, matching the coverage pattern already in place for OF3 and Boltz-2. Closes #49.

- **`test_af2_config.py`** — Config loading from env, required `ALPHAFOLD_COMPONENTS_IMAGE`, viewer URL, parallelism defaults, `to_dict()` shape, supported GPUs
- **`test_af2_hardware.py`** — GPU auto-selection tiers (A100 minimum post L4-removal), monomer threshold at 1500 residues, multimer at 1000, relax GPU matching (A100→A100, A100_80GB→A100), multi-GPU machine naming, mmseqs2 vs jackhmmer data pipeline config, unsupported GPU upgrade path
- **`test_af2_pipeline.py`** — Source inspection: configure/data/predict/relax steps, ParallelFor, retry policies, FLEX_START on GPU tasks only, mmseqs2 code path, component CLI args (predict_relax, data_pipeline, configure_run, version)
- **`test_af2_compilation.py`** — Compile monomer and FLEX_START pipelines to YAML, verify predict/relax/data-pipeline present, config module isolation (AF2→OF3, AF2→Boltz-2)

## Test plan
- [x] 59/59 passing: `uv run pytest tests/unit/models/af2/ -v`