### PR TITLE
feat(foldrun): configurable version ARGs for AF2 and OF3 containers

### DIFF
--- a/applications/foldrun/README.md
+++ b/applications/foldrun/README.md
@@ -138,6 +138,20 @@ GCS_SOURCE_BUCKET=THEIR_PROJECT-foldrun-gdbs ./deploy-all.sh YOUR_PROJECT_ID
 DOWNLOAD_MODE=full ./deploy-all.sh YOUR_PROJECT_ID  # Full BFD database (~272GB)
 ```
 
+**Pinned model versions** — override without editing any files:
+```bash
+# Upgrade OpenFold3 to a newer release
+OF3_VERSION=0.4.0 ./deploy-all.sh YOUR_PROJECT_ID --steps build
+
+# Pin AlphaFold2 to a specific git commit
+AF2_VERSION=abc123def ./deploy-all.sh YOUR_PROJECT_ID --steps build
+
+# Upgrade Boltz-2
+BOLTZ_VERSION=2.3.0 ./deploy-all.sh YOUR_PROJECT_ID --steps build
+```
+
+Default versions are defined in `deploy-all.sh` and match the tested, pinned values in each container's `Dockerfile`.
+
 ### Step 3: Verify
 
 ```bash

--- a/applications/foldrun/cloudbuild.yaml
+++ b/applications/foldrun/cloudbuild.yaml
@@ -199,6 +199,7 @@ steps:
     dir: 'src/alphafold-components'
     args: [
       'build',
+      '--build-arg', 'AF2_VERSION=${_AF2_VERSION}',
       '-t', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest',
       '--cache-from', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest',
       '.'
@@ -218,6 +219,7 @@ steps:
     dir: 'src/openfold3-components'
     args: [
       'build',
+      '--build-arg', 'OF3_VERSION=${_OF3_VERSION}',
       '-t', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest',
       '.'
     ]
@@ -379,7 +381,9 @@ substitutions:
   _FILESTORE_ID: foldrun-nfs
   _AGENT_SA_EMAIL: required_sa_email
   _PIPELINES_SA_EMAIL: required_pipelines_sa_email
-  _BOLTZ_VERSION: 2.2.1
+  _AF2_VERSION: "42719e135a62438aa651d2bc1d143626083c3703"
+  _OF3_VERSION: "0.3.1"
+  _BOLTZ_VERSION: "2.2.1"
 timeout: 3600s
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -43,6 +43,8 @@ usage() {
     echo ""
     echo "Environment variables:"
     echo "  DOWNLOAD_MODE      Database download mode: reduced (default) or full"
+    echo "  AF2_VERSION        AlphaFold2 git commit to build (default: pinned commit)"
+    echo "  OF3_VERSION        OpenFold3 Docker image tag to use (default: 0.3.1)"
     echo "  BOLTZ_VERSION      Boltz-2 pip package version to install (default: 2.2.1)"
     echo ""
     echo "  The following override the auto-detected naming conventions for"
@@ -120,6 +122,8 @@ done
 PROJECT_ID=${POSITIONAL_ARGS[0]:-$(gcloud config get-value project)}
 REGION=${POSITIONAL_ARGS[1]:-"us-central1"}
 DOWNLOAD_MODE=${DOWNLOAD_MODE:-"reduced"}
+AF2_VERSION=${AF2_VERSION:-"42719e135a62438aa651d2bc1d143626083c3703"}
+OF3_VERSION=${OF3_VERSION:-"0.3.1"}
 BOLTZ_VERSION=${BOLTZ_VERSION:-"2.2.1"}
 IAP_ACCESS_DOMAIN=${IAP_ACCESS_DOMAIN:-$(gcloud config get-value account | awk -F '@' '{print $2}')}
 TERRAFORM_DIR="terraform"
@@ -277,7 +281,7 @@ if $run_build; then
     gcloud builds submit . \
         --config cloudbuild.yaml \
         --project "$PROJECT_ID" \
-        --substitutions=_REGION="$REGION",_BUCKET_NAME="$GCS_BUCKET",_FILESTORE_ID="$FILESTORE_ID",_AR_REPO="$AR_REPO",_AGENT_SA_EMAIL="$AGENT_SA_EMAIL",_PIPELINES_SA_EMAIL="$PIPELINES_SA_EMAIL",_DATABASES_BUCKET="$DATABASES_BUCKET",_BOLTZ_VERSION="$BOLTZ_VERSION" \
+        --substitutions=_REGION="$REGION",_BUCKET_NAME="$GCS_BUCKET",_FILESTORE_ID="$FILESTORE_ID",_AR_REPO="$AR_REPO",_AGENT_SA_EMAIL="$AGENT_SA_EMAIL",_PIPELINES_SA_EMAIL="$PIPELINES_SA_EMAIL",_DATABASES_BUCKET="$DATABASES_BUCKET",_AF2_VERSION="$AF2_VERSION",_OF3_VERSION="$OF3_VERSION",_BOLTZ_VERSION="$BOLTZ_VERSION" \
         --machine-type=e2-highcpu-8 \
         --service-account="projects/${PROJECT_ID}/serviceAccounts/${BUILD_SA_EMAIL}"
 fi

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -17,7 +17,7 @@ FROM nvidia/cuda:${CUDA}-cudnn8-runtime-ubuntu20.04
 # FROM directive resets ARGS, so we specify again (the value is retained if
 # previously set).
 ARG CUDA
-ARG ALPHAFOLD_COMMIT=42719e135a62438aa651d2bc1d143626083c3703
+ARG AF2_VERSION="42719e135a62438aa651d2bc1d143626083c3703"
 
 # Use bash to support string substitution.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -71,7 +71,7 @@ RUN ln -sf /usr/lib/x86_64-linux-gnu/libffi.so.7 /opt/conda/lib/libffi.so.7
 ENV LD_LIBRARY_PATH="/opt/conda/lib:$LD_LIBRARY_PATH"
 
 RUN git clone https://github.com/deepmind/alphafold.git /app/alphafold
-RUN git -C /app/alphafold reset --hard $ALPHAFOLD_COMMIT
+RUN git -C /app/alphafold reset --hard $AF2_VERSION
 RUN wget -q -P /app/alphafold/alphafold/common/ \
   https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
 

--- a/applications/foldrun/src/openfold3-components/Dockerfile
+++ b/applications/foldrun/src/openfold3-components/Dockerfile
@@ -1,4 +1,5 @@
-FROM openfoldconsortium/openfold3:0.3.1
+ARG OF3_VERSION="0.3.1"
+FROM openfoldconsortium/openfold3:${OF3_VERSION}
 
 # No GCS libraries needed — all I/O via NFS mounts and KFP artifacts,
 # consistent with the AF2 container.


### PR DESCRIPTION
## Summary

Applies the same `ARG VERSION` pattern already used by Boltz-2 to AF2 and OF3, so version upgrades require no code changes.

**AlphaFold2:**
- `Dockerfile`: renamed `ALPHAFOLD_COMMIT` → `AF2_VERSION` (same pinned commit hash, cleaner name)
- `cloudbuild.yaml`: adds `--build-arg AF2_VERSION=${_AF2_VERSION}`
- `deploy-all.sh`: adds `AF2_VERSION` env var with current commit as default

**OpenFold3:**
- `Dockerfile`: adds `ARG OF3_VERSION="0.3.1"`, uses it in `FROM openfoldconsortium/openfold3:${OF3_VERSION}`
- `cloudbuild.yaml`: adds `--build-arg OF3_VERSION=${_OF3_VERSION}`
- `deploy-all.sh`: adds `OF3_VERSION` env var defaulting to `0.3.1`

## Usage after this change

```bash
# Upgrade OF3 without editing any files
OF3_VERSION=0.4.0 ./deploy-all.sh PROJECT_ID --steps build

# Pin a specific AF2 commit
AF2_VERSION=abc123def ./deploy-all.sh PROJECT_ID --steps build
```

## Test plan
- [ ] Verify `docker build --build-arg AF2_VERSION=... src/alphafold-components/` works
- [ ] Verify `docker build --build-arg OF3_VERSION=0.3.1 src/openfold3-components/` works

Closes #45