### PR TITLE
fix(foldrun): rename AF2 KFP pipeline to alphafold2-inference-pipeline

### DIFF
--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/pipeline/pipelines/alphafold_inference_pipeline.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/pipeline/pipelines/alphafold_inference_pipeline.py
@@ -51,7 +51,7 @@ def create_alphafold_inference_pipeline(strategy: str = "STANDARD", msa_method: 
         dp_strategy = "STANDARD"  # CPU-only jobs cannot use FLEX_START
 
     @dsl.pipeline(
-        name="alphafold-inference-pipeline",
+        name="alphafold2-inference-pipeline",
         description="AlphaFold inference using original data pipeline with configurable scheduling.",
     )
     def alphafold_inference_pipeline(

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/analyze_job_deep.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/analyze_job_deep.py
@@ -405,7 +405,7 @@ class AF2AnalyzeJobDeepTool(AF2Tool):
                     "type": "string",
                     "description": (
                         "The AlphaFold pipeline job ID to analyze (e.g., "
-                        "'alphafold-inference-pipeline-20251110082144')"
+                        "'alphafold2-inference-pipeline-20251110082144')"
                     ),
                 },
                 "detail_level": {

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/cleanup_gcs_files.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/cleanup_gcs_files.py
@@ -207,10 +207,12 @@ class AF2CleanupGCSFilesTool(AF2Tool):
                 job_name = job_name.split("/")[-1]
 
         # Extract timestamp from job ID for timestamped directory search
-        # Job ID format: alphafold-inference-pipeline-20251112172826
+        # Job ID format: alphafold2-inference-pipeline-20251112172826 (new)
+        #                alphafold-inference-pipeline-20251112172826  (legacy)
         # Timestamped dir: pipeline_runs/20251112_172826/
         timestamp_search = None
-        if "alphafold-inference-pipeline-" in job_id.lower():
+        if "alphafold2-inference-pipeline-" in job_id.lower() or \
+                "alphafold-inference-pipeline-" in job_id.lower():
             timestamp = job_id.split("-")[-1]  # Get the timestamp part
             if timestamp.isdigit() and len(timestamp) >= 14:
                 # Format as YYYYMMDD_HHMMSS

--- a/applications/foldrun/foldrun-agent/foldrun_app/skills/results_analysis/tools.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/skills/results_analysis/tools.py
@@ -254,7 +254,7 @@ def analyze_job(job_id: str, detail_level: str = "summary") -> dict:
     - Configuration details
 
     Args:
-        job_id: The AlphaFold pipeline job ID (e.g., 'alphafold-inference-pipeline-20251110082144')
+        job_id: The AlphaFold pipeline job ID (e.g., 'alphafold2-inference-pipeline-20251110082144')
         detail_level: Level of detail - 'summary' (quick overview, default) or 'detailed' (with Cloud Logging error logs - fetches top 5 ERROR logs per failed task)
 
     Returns:

--- a/applications/foldrun/foldrun-agent/foldrun_app/skills/visualization/tools.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/skills/visualization/tools.py
@@ -84,7 +84,7 @@ def open_structure_viewer(
     prediction jobs.
 
     Args:
-        job_id: Pipeline job ID (e.g., 'alphafold-inference-pipeline-20250421110959')
+        job_id: Pipeline job ID (e.g., 'alphafold2-inference-pipeline-20250421110959')
         pdb_uri: GCS URI to PDB file (optional, defaults to ranked_0.pdb from job)
         summary_uri: GCS URI to analysis summary.json (optional, auto-constructed from job_id)
         model_name: Display name for the model (default: 'Best Model')


### PR DESCRIPTION
## Summary

Renames the AF2 `@dsl.pipeline(name=...)` from `alphafold-inference-pipeline` to `alphafold2-inference-pipeline` for consistency with OF3 and Boltz-2. Closes #48.

## Changes

- **`alphafold_inference_pipeline.py`**: `name="alphafold2-inference-pipeline"`
- **`cleanup_gcs_files.py`**: accepts both `alphafold2-inference-pipeline-` and `alphafold-inference-pipeline-` prefixes — existing jobs remain cleanable
- **`analyze_job_deep.py`**, **`results_analysis/tools.py`**, **`visualization/tools.py`**: docstring examples updated

## Backward compatibility

The viewer resolves jobs by timestamp regex (not prefix), so existing `alphafold-inference-pipeline-{ts}` jobs remain fully viewable. Only `cleanup_gcs_files.py` matched on prefix — it now accepts both old and new names.

## Test plan
- [ ] Submit a new AF2 job — confirm it appears as `alphafold2-inference-pipeline-{ts}` in Vertex AI
- [ ] Run cleanup tool against an old `alphafold-inference-pipeline-{ts}` job — confirm it still works

Closes #48