### PR TITLE
foldrun: add OF3 template support using pdb_seqres + pdb_mmcif

### DIFF
--- a/applications/foldrun/README.md
+++ b/applications/foldrun/README.md
@@ -133,21 +133,52 @@ GCS_SOURCE_BUCKET=THEIR_PROJECT-foldrun-gdbs ./deploy-all.sh YOUR_PROJECT_ID
 ### Other deploy options
 ```bash
 ./deploy-all.sh YOUR_PROJECT_ID --steps infra    # Only Terraform
-./deploy-all.sh YOUR_PROJECT_ID --steps build    # Only Cloud Build
+./deploy-all.sh YOUR_PROJECT_ID --steps build    # Only Cloud Build (all containers)
 ./deploy-all.sh YOUR_PROJECT_ID --steps data     # Only database downloads
 DOWNLOAD_MODE=full ./deploy-all.sh YOUR_PROJECT_ID  # Full BFD database (~272GB)
 ```
 
+**Targeted rebuilds** — rebuild only what changed (much faster than full build):
+```bash
+# Rebuild just the OF3 container + redeploy agent (~10 min vs ~25 min full build)
+./deploy-all.sh YOUR_PROJECT_ID --steps build --build-target of3
+
+# Redeploy agent only — no container rebuilds (~3 min, e.g. after agent code change)
+./deploy-all.sh YOUR_PROJECT_ID --steps build --build-target agent
+
+# Rebuild a single analysis job
+./deploy-all.sh YOUR_PROJECT_ID --steps build --build-target of3-analysis
+
+# Rebuild multiple targets (comma-separated)
+./deploy-all.sh YOUR_PROJECT_ID --steps build --build-target of3,viewer
+```
+
+Available `--build-target` values:
+
+| Target | What rebuilds |
+|--------|--------------|
+| `all` | Everything (default) |
+| `of3` | openfold3-components container + agent |
+| `af2` | alphafold-components container + agent |
+| `boltz2` | boltz2-components container + agent |
+| `viewer` | foldrun-viewer Cloud Run service + agent |
+| `agent` | Agent Engine only (no container rebuilds) |
+| `of3-analysis` | of3-analysis-job Cloud Run Job only |
+| `af2-analysis` | af2-analysis-job Cloud Run Job only |
+| `boltz2-analysis` | boltz2-analysis-job Cloud Run Job only |
+
+The agent is automatically redeployed whenever any non-analysis target is included.
+
 **Pinned model versions** — override without editing any files:
 ```bash
 # Upgrade OpenFold3 to a newer release
-OF3_VERSION=0.4.0 ./deploy-all.sh YOUR_PROJECT_ID --steps build
+OF3_VERSION=0.4.0 ./deploy-all.sh YOUR_PROJECT_ID --steps build --build-target of3
 
 # Pin AlphaFold2 to a specific git commit
-AF2_VERSION=abc123def ./deploy-all.sh YOUR_PROJECT_ID --steps build
+AF2_VERSION=abc123def ./deploy-all.sh YOUR_PROJECT_ID --steps build --build-target af2
 
 # Upgrade Boltz-2
-BOLTZ_VERSION=2.3.0 ./deploy-all.sh YOUR_PROJECT_ID --steps build
+BOLTZ_VERSION=2.3.0 ./deploy-all.sh YOUR_PROJECT_ID --steps build --build-target boltz2
 ```
 
 Default versions are defined in `deploy-all.sh` and match the tested, pinned values in each container's `Dockerfile`.
@@ -289,8 +320,8 @@ foldrun/
 │   │   │   ├── of3/            # OpenFold3 plugin
 │   │   │   │   ├── config.py   # OF3Config (image, params path, viewer URL)
 │   │   │   │   ├── base.py     # OF3Tool (GPU tiers: A100/A100_80GB, no relax)
-│   │   │   │   ├── pipeline/   # KFP: ConfigureSeeds → MSA → ParallelFor[Predict]
-│   │   │   │   ├── tools/      # submit, analyze, get_results, open_viewer
+│   │   │   │   ├── pipeline/   # KFP: ConfigureSeeds → MSA+templates → ParallelFor[Predict]
+│   │   │   │   ├── tools/      # submit (use_templates=True default), analyze, get_results, open_viewer
 │   │   │   │   └── utils/      # Input converter (FASTA→OF3 JSON), pipeline utils
 │   │   │   └── boltz2/         # Boltz-2 plugin (optional — enabled by BOLTZ2_COMPONENTS_IMAGE)
 │   │   │       ├── config.py   # BOLTZ2Config (image, cache path)
@@ -406,14 +437,15 @@ uv run python scripts/setup_data.py --list
 /mnt/nfs/foldrun/
   uniref90/              # Shared (AF2, OF3, Boltz-2)
   mgnify/                # Shared (AF2, OF3, Boltz-2)
-  pdb_seqres/            # Shared (AF2, OF3)
+  pdb_seqres/            # Shared (AF2, OF3) — also used for OF3 template search
   uniprot/               # Shared (AF2, OF3)
-  pdb_mmcif/             # Shared (AF2, OF3)
+  pdb_mmcif/             # Shared (AF2, OF3) — CIF structures for OF3 template featurization
   alphafold2/params/     # AF2 only
   small_bfd/             # AF2 only
   pdb70/                 # AF2 only
   of3/params/            # OF3 only (~2GB weights)
   of3/ccd/               # OF3 only (~500MB Chemical Component Dictionary)
+  of3_msas/              # OF3 runtime — per-job MSA + template alignment files (auto-created)
   rfam/                  # OF3 only (RNA MSA via nhmmer)
   rnacentral/            # OF3 only (RNA MSA via nhmmer)
   boltz2/cache/          # Boltz-2 only — boltz2_conf.ckpt, boltz2_aff.ckpt, mols/ (CCD)

--- a/applications/foldrun/cloudbuild.yaml
+++ b/applications/foldrun/cloudbuild.yaml
@@ -12,31 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# _BUILD_TARGET controls which components are built/deployed.
+# Supported values (comma-separated):
+#   all            - build and deploy everything (default)
+#   viewer         - foldrun-viewer Cloud Run service
+#   af2            - alphafold-components container
+#   of3            - openfold3-components container
+#   boltz2         - boltz2-components container
+#   agent          - Vertex AI Agent Engine only (no container rebuilds)
+#   af2-analysis   - af2-analysis-job Cloud Run Job
+#   of3-analysis   - of3-analysis-job Cloud Run Job
+#   boltz2-analysis- boltz2-analysis-job Cloud Run Job
+#
+# The agent is automatically included whenever viewer, af2, of3, boltz2,
+# or agent is in the target list (anything except analysis-only targets).
+# Examples:
+#   _BUILD_TARGET=of3            # rebuild OF3 container + redeploy agent
+#   _BUILD_TARGET=agent          # redeploy agent only, no container rebuilds
+#   _BUILD_TARGET=of3,viewer     # rebuild OF3 + viewer + redeploy agent
+#   _BUILD_TARGET=of3-analysis   # rebuild only the OF3 analysis Cloud Run Job
+
 steps:
   # ============================================================================
   # 1. FoldRun Viewer (Cloud Run Service)
   # ============================================================================
-  - id: 'pull-viewer'
+  - id: 'build-push-viewer'
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest || exit 0']
+    args:
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",viewer,"* ]]; then
+          docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest || true
+          docker build \
+            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest \
+            --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest \
+            src/foldrun-viewer/
+          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest
+        else
+          echo "Skipping viewer build (BUILD_TARGET=${_BUILD_TARGET})"
+        fi
     waitFor: ['-']
-
-  - id: 'build-viewer'
-    name: 'gcr.io/cloud-builders/docker'
-    dir: 'src/foldrun-viewer'
-    args: [
-      'build',
-      '-t', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest',
-      '--cache-from', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest',
-      '.'
-    ]
-    waitFor: ['pull-viewer']
-
-  - id: 'push-viewer'
-    name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest']
-    waitFor: ['build-viewer']
 
   - id: 'deploy-viewer'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -44,220 +61,217 @@ steps:
     args:
       - '-c'
       - |
-        gcloud run deploy foldrun-viewer \
-          --image ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest \
-          --region ${_REGION} \
-          --set-env-vars PROJECT_ID=$PROJECT_ID,BUCKET_NAME=${_BUCKET_NAME},REGION=${_REGION}
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",viewer,"* ]]; then
+          gcloud run deploy foldrun-viewer \
+            --image ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest \
+            --region ${_REGION} \
+            --set-env-vars PROJECT_ID=$PROJECT_ID,BUCKET_NAME=${_BUCKET_NAME},REGION=${_REGION}
 
-        # Capture the viewer URL for the agent deploy step
-        gcloud run services describe foldrun-viewer \
-          --region ${_REGION} \
-          --format 'value(status.url)' > /workspace/viewer_url.txt
-        echo "Viewer URL: $$(cat /workspace/viewer_url.txt)"
-    waitFor: ['push-viewer']
+          gcloud run services describe foldrun-viewer \
+            --region ${_REGION} \
+            --format 'value(status.url)' > /workspace/viewer_url.txt
+          echo "Viewer URL: $$(cat /workspace/viewer_url.txt)"
+        else
+          echo "Skipping viewer deploy (BUILD_TARGET=${_BUILD_TARGET})"
+          # Fetch existing URL so deploy-agent-engine can use it
+          gcloud run services describe foldrun-viewer \
+            --region ${_REGION} \
+            --format 'value(status.url)' > /workspace/viewer_url.txt 2>/dev/null || echo "" > /workspace/viewer_url.txt
+        fi
+    waitFor: ['build-push-viewer']
 
   # ============================================================================
   # 2. AF2 Analysis Job (Cloud Run Job)
   # ============================================================================
-  - id: 'pull-analysis-job'
+  - id: 'build-push-af2-analysis'
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/af2-analysis-job:latest || exit 0']
+    args:
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",af2-analysis,"* ]]; then
+          docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/af2-analysis-job:latest || true
+          docker build \
+            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/af2-analysis-job:latest \
+            --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/af2-analysis-job:latest \
+            src/af2-analysis-job/
+          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/af2-analysis-job:latest
+        else
+          echo "Skipping af2-analysis build (BUILD_TARGET=${_BUILD_TARGET})"
+        fi
     waitFor: ['-']
 
-  - id: 'build-analysis-job'
-    name: 'gcr.io/cloud-builders/docker'
-    dir: 'src/af2-analysis-job'
-    args: [
-      'build',
-      '-t', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/af2-analysis-job:latest',
-      '--cache-from', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/af2-analysis-job:latest',
-      '.'
-    ]
-    waitFor: ['pull-analysis-job']
-
-  - id: 'push-analysis-job'
-    name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/af2-analysis-job:latest']
-    waitFor: ['build-analysis-job']
-
-  - id: 'deploy-analysis-job'
+  - id: 'deploy-af2-analysis'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: gcloud
+    entrypoint: bash
     args:
-      - 'run'
-      - 'jobs'
-      - 'deploy'
-      - 'af2-analysis-job'
-      - '--image'
-      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/af2-analysis-job:latest'
-      - '--region'
-      - '${_REGION}'
-      - '--service-account'
-      - 'foldrun-analysis-sa@$PROJECT_ID.iam.gserviceaccount.com'
-      - '--set-env-vars'
-      - 'GCS_BUCKET=${_BUCKET_NAME},PROJECT_ID=$PROJECT_ID,REGION=${_REGION}'
-    waitFor: ['push-analysis-job']
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",af2-analysis,"* ]]; then
+          gcloud run jobs deploy af2-analysis-job \
+            --image ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/af2-analysis-job:latest \
+            --region ${_REGION} \
+            --service-account foldrun-analysis-sa@$PROJECT_ID.iam.gserviceaccount.com \
+            --set-env-vars GCS_BUCKET=${_BUCKET_NAME},PROJECT_ID=$PROJECT_ID,REGION=${_REGION}
+        else
+          echo "Skipping af2-analysis deploy (BUILD_TARGET=${_BUILD_TARGET})"
+        fi
+    waitFor: ['build-push-af2-analysis']
 
   # ============================================================================
   # 2b. OF3 Analysis Job (Cloud Run Job)
   # ============================================================================
-  - id: 'pull-of3-analysis-job'
+  - id: 'build-push-of3-analysis'
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/of3-analysis-job:latest || exit 0']
+    args:
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",of3-analysis,"* ]]; then
+          docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/of3-analysis-job:latest || true
+          docker build \
+            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/of3-analysis-job:latest \
+            --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/of3-analysis-job:latest \
+            src/of3-analysis-job/
+          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/of3-analysis-job:latest
+        else
+          echo "Skipping of3-analysis build (BUILD_TARGET=${_BUILD_TARGET})"
+        fi
     waitFor: ['-']
 
-  - id: 'build-of3-analysis-job'
-    name: 'gcr.io/cloud-builders/docker'
-    dir: 'src/of3-analysis-job'
-    args: [
-      'build',
-      '-t', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/of3-analysis-job:latest',
-      '--cache-from', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/of3-analysis-job:latest',
-      '.'
-    ]
-    waitFor: ['pull-of3-analysis-job']
-
-  - id: 'push-of3-analysis-job'
-    name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/of3-analysis-job:latest']
-    waitFor: ['build-of3-analysis-job']
-
-  - id: 'deploy-of3-analysis-job'
+  - id: 'deploy-of3-analysis'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: gcloud
+    entrypoint: bash
     args:
-      - 'run'
-      - 'jobs'
-      - 'deploy'
-      - 'of3-analysis-job'
-      - '--image'
-      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/of3-analysis-job:latest'
-      - '--region'
-      - '${_REGION}'
-      - '--service-account'
-      - 'foldrun-analysis-sa@$PROJECT_ID.iam.gserviceaccount.com'
-      - '--set-env-vars'
-      - 'GCS_BUCKET=${_BUCKET_NAME},PROJECT_ID=$PROJECT_ID,REGION=${_REGION}'
-    waitFor: ['push-of3-analysis-job']
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",of3-analysis,"* ]]; then
+          gcloud run jobs deploy of3-analysis-job \
+            --image ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/of3-analysis-job:latest \
+            --region ${_REGION} \
+            --service-account foldrun-analysis-sa@$PROJECT_ID.iam.gserviceaccount.com \
+            --set-env-vars GCS_BUCKET=${_BUCKET_NAME},PROJECT_ID=$PROJECT_ID,REGION=${_REGION}
+        else
+          echo "Skipping of3-analysis deploy (BUILD_TARGET=${_BUILD_TARGET})"
+        fi
+    waitFor: ['build-push-of3-analysis']
 
   # ============================================================================
   # 2c. Boltz-2 Analysis Job (Cloud Run Job)
   # ============================================================================
-  - id: 'pull-boltz2-analysis-job'
+  - id: 'build-push-boltz2-analysis'
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-analysis-job:latest || exit 0']
-    waitFor: ['-']
-
-  - id: 'build-boltz2-analysis-job'
-    name: 'gcr.io/cloud-builders/docker'
-    dir: 'src/boltz2-analysis-job'
-    args: [
-      'build',
-      '-t', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-analysis-job:latest',
-      '--cache-from', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-analysis-job:latest',
-      '.'
-    ]
-    waitFor: ['pull-boltz2-analysis-job']
-
-  - id: 'push-boltz2-analysis-job'
-    name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-analysis-job:latest']
-    waitFor: ['build-boltz2-analysis-job']
-
-  - id: 'deploy-boltz2-analysis-job'
-    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: gcloud
     args:
-      - 'run'
-      - 'jobs'
-      - 'deploy'
-      - 'boltz2-analysis-job'
-      - '--image'
-      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-analysis-job:latest'
-      - '--region'
-      - '${_REGION}'
-      - '--service-account'
-      - 'foldrun-analysis-sa@$PROJECT_ID.iam.gserviceaccount.com'
-      - '--set-env-vars'
-      - 'GCS_BUCKET=${_BUCKET_NAME},PROJECT_ID=$PROJECT_ID,REGION=${_REGION}'
-    waitFor: ['push-boltz2-analysis-job']
-
-  # ============================================================================
-  # 3. AlphaFold Components (Pipeline Container Image)
-  # ============================================================================
-  - id: 'pull-alphafold-components'
-    name: 'gcr.io/cloud-builders/docker'
-    entrypoint: 'bash'
-    args: ['-c', 'docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest || exit 0']
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",boltz2-analysis,"* ]]; then
+          docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-analysis-job:latest || true
+          docker build \
+            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-analysis-job:latest \
+            --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-analysis-job:latest \
+            src/boltz2-analysis-job/
+          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-analysis-job:latest
+        else
+          echo "Skipping boltz2-analysis build (BUILD_TARGET=${_BUILD_TARGET})"
+        fi
     waitFor: ['-']
 
-  - id: 'build-alphafold-components'
-    name: 'gcr.io/cloud-builders/docker'
-    dir: 'src/alphafold-components'
-    args: [
-      'build',
-      '--build-arg', 'AF2_VERSION=${_AF2_VERSION}',
-      '-t', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest',
-      '--cache-from', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest',
-      '.'
-    ]
-    waitFor: ['pull-alphafold-components']
+  - id: 'deploy-boltz2-analysis'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",boltz2-analysis,"* ]]; then
+          gcloud run jobs deploy boltz2-analysis-job \
+            --image ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-analysis-job:latest \
+            --region ${_REGION} \
+            --service-account foldrun-analysis-sa@$PROJECT_ID.iam.gserviceaccount.com \
+            --set-env-vars GCS_BUCKET=${_BUCKET_NAME},PROJECT_ID=$PROJECT_ID,REGION=${_REGION}
+        else
+          echo "Skipping boltz2-analysis deploy (BUILD_TARGET=${_BUILD_TARGET})"
+        fi
+    waitFor: ['build-push-boltz2-analysis']
 
-  - id: 'push-alphafold-components'
+  # ============================================================================
+  # 3. AlphaFold2 Components (Pipeline Container Image)
+  # ============================================================================
+  - id: 'build-push-af2-components'
     name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest']
-    waitFor: ['build-alphafold-components']
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",af2,"* ]]; then
+          docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest || true
+          docker build \
+            --build-arg AF2_VERSION=${_AF2_VERSION} \
+            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest \
+            --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest \
+            src/alphafold-components/
+          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest
+        else
+          echo "Skipping af2-components build (BUILD_TARGET=${_BUILD_TARGET})"
+        fi
+    waitFor: ['-']
 
   # ============================================================================
   # 3b. OpenFold3 Components (Pipeline Container Image)
   # ============================================================================
-  - id: 'build-openfold3-components'
+  - id: 'build-push-of3-components'
     name: 'gcr.io/cloud-builders/docker'
-    dir: 'src/openfold3-components'
-    args: [
-      'build',
-      '--build-arg', 'OF3_VERSION=${_OF3_VERSION}',
-      '-t', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest',
-      '.'
-    ]
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",of3,"* ]]; then
+          docker build \
+            --build-arg OF3_VERSION=${_OF3_VERSION} \
+            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest \
+            src/openfold3-components/
+          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest
+        else
+          echo "Skipping of3-components build (BUILD_TARGET=${_BUILD_TARGET})"
+        fi
     waitFor: ['-']
-
-  - id: 'push-openfold3-components'
-    name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest']
-    waitFor: ['build-openfold3-components']
 
   # ============================================================================
   # 3c. Boltz-2 Components (Pipeline Container Image)
   # ============================================================================
-  - id: 'pull-boltz2-components'
+  - id: 'build-push-boltz2-components'
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest || exit 0']
+    args:
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",boltz2,"* ]]; then
+          docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest || true
+          docker build \
+            --build-arg BOLTZ_VERSION=${_BOLTZ_VERSION} \
+            --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest \
+            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest \
+            src/boltz2-components/
+          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest
+        else
+          echo "Skipping boltz2-components build (BUILD_TARGET=${_BUILD_TARGET})"
+        fi
     waitFor: ['-']
 
-  - id: 'build-boltz2-components'
-    name: 'gcr.io/cloud-builders/docker'
-    dir: 'src/boltz2-components'
-    args: [
-      'build',
-      '--build-arg', 'BOLTZ_VERSION=${_BOLTZ_VERSION}',
-      '--cache-from', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest',
-      '-t', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest',
-      '.'
-    ]
-    waitFor: ['pull-boltz2-components']
-
-  - id: 'push-boltz2-components'
-    name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest']
-    waitFor: ['build-boltz2-components']
-
   # ============================================================================
-  # 4. Agentic AF2 Agent (Vertex AI Reasoning Engine)
+  # 4. FoldRun Agent (Vertex AI Agent Engine)
+  # Runs whenever any component or the agent itself is in the target.
+  # Skipped only for analysis-job-only targets.
   # ============================================================================
   - id: 'deploy-agent-engine'
     name: 'python:3.12-slim'
@@ -266,16 +280,29 @@ steps:
     args:
       - '-c'
       - |
+        _t=",${_BUILD_TARGET},"
+        _skip_agent=false
+        # Skip agent deploy only when every token in BUILD_TARGET ends with "-analysis"
+        if [[ "${_BUILD_TARGET}" != "all" ]] && [[ "${_BUILD_TARGET}" != "agent" ]] && \
+           [[ "${_BUILD_TARGET}" != *",agent,"* ]] && \
+           [[ "$$_t" != *",viewer,"* ]] && [[ "$$_t" != *",af2,"* ]] && \
+           [[ "$$_t" != *",of3,"* ]] && [[ "$$_t" != *",boltz2,"* ]]; then
+          _skip_agent=true
+        fi
+
+        if [[ "$$_skip_agent" == "true" ]]; then
+          echo "Skipping agent deploy (BUILD_TARGET=${_BUILD_TARGET})"
+          exit 0
+        fi
+
         apt-get update && apt-get install -y curl
         curl -LsSf https://astral.sh/uv/install.sh | sh
         export PATH="$$HOME/.local/bin:$$PATH"
         uv sync
 
-        # Export requirements for Agent Engine (strip hashes/dev dependencies)
         (uv export --no-hashes --no-header --no-dev --no-emit-project --no-annotate > foldrun_app/app_utils/.requirements.txt 2>/dev/null || \
          uv export --no-hashes --no-header --no-dev --no-emit-project > foldrun_app/app_utils/.requirements.txt)
 
-        # Set env vars needed by agent module at import time
         export GCP_PROJECT_ID=$PROJECT_ID
         export GCP_REGION=${_REGION}
         export GCS_BUCKET_NAME=${_BUCKET_NAME}
@@ -285,42 +312,43 @@ steps:
         export OPENFOLD3_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest
         export BOLTZ2_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest
 
-        # Read viewer URL captured from the deploy-viewer step
         VIEWER_URL=$$(cat /workspace/viewer_url.txt)
         export AF2_VIEWER_URL=$$VIEWER_URL
 
-        # Deploy using the custom script inside the python project
         uv run -m foldrun_app.app_utils.deploy \
           --project=$PROJECT_ID \
           --location=${_REGION} \
           --service-account=${_AGENT_SA_EMAIL} \
           --set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_REGION=${_REGION},GCS_BUCKET_NAME=${_BUCKET_NAME},GCS_DATABASES_BUCKET=${_DATABASES_BUCKET},FILESTORE_ID=${_FILESTORE_ID},ALPHAFOLD_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest,OPENFOLD3_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest,BOLTZ2_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest,AF2_VIEWER_URL=$$VIEWER_URL,OF3_ANALYSIS_JOB_NAME=of3-analysis-job,BOLTZ2_ANALYSIS_JOB_NAME=boltz2-analysis-job,PIPELINES_SA_EMAIL=${_PIPELINES_SA_EMAIL}
-    waitFor: ['deploy-viewer', 'push-alphafold-components', 'push-openfold3-components', 'push-boltz2-components']
+    waitFor: ['deploy-viewer', 'build-push-af2-components', 'build-push-of3-components', 'build-push-boltz2-components']
 
   # ============================================================================
   # 4b. FoldRun A2A Proxy (Cloud Run Service — optional)
   # ============================================================================
-  - id: 'pull-a2a'
+  - id: 'build-push-a2a'
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-a2a:latest || exit 0']
+    args:
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        _skip_agent=false
+        if [[ "${_BUILD_TARGET}" != "all" ]] && [[ "${_BUILD_TARGET}" != "agent" ]] && \
+           [[ "$$_t" != *",viewer,"* ]] && [[ "$$_t" != *",af2,"* ]] && \
+           [[ "$$_t" != *",of3,"* ]] && [[ "$$_t" != *",boltz2,"* ]]; then
+          _skip_agent=true
+        fi
+        if [[ "$$_skip_agent" == "true" ]]; then
+          echo "Skipping a2a build (BUILD_TARGET=${_BUILD_TARGET})"
+          exit 0
+        fi
+        docker pull ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-a2a:latest || true
+        docker build \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-a2a:latest \
+          --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-a2a:latest \
+          src/foldrun-a2a/
+        docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-a2a:latest
     waitFor: ['-']
-
-  - id: 'build-a2a'
-    name: 'gcr.io/cloud-builders/docker'
-    dir: 'src/foldrun-a2a'
-    args: [
-      'build',
-      '-t', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-a2a:latest',
-      '--cache-from', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-a2a:latest',
-      '.'
-    ]
-    waitFor: ['pull-a2a']
-
-  - id: 'push-a2a'
-    name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-a2a:latest']
-    waitFor: ['build-a2a']
 
   - id: 'deploy-a2a'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -328,7 +356,18 @@ steps:
     args:
       - '-c'
       - |
-        # Read Agent Engine resource ID written by deploy-agent-engine step
+        _t=",${_BUILD_TARGET},"
+        _skip_agent=false
+        if [[ "${_BUILD_TARGET}" != "all" ]] && [[ "${_BUILD_TARGET}" != "agent" ]] && \
+           [[ "$$_t" != *",viewer,"* ]] && [[ "$$_t" != *",af2,"* ]] && \
+           [[ "$$_t" != *",of3,"* ]] && [[ "$$_t" != *",boltz2,"* ]]; then
+          _skip_agent=true
+        fi
+        if [[ "$$_skip_agent" == "true" ]]; then
+          echo "Skipping a2a deploy (BUILD_TARGET=${_BUILD_TARGET})"
+          exit 0
+        fi
+
         AGENT_ENGINE_RESOURCE=$$(python3 -c "import json; print(json.load(open('/workspace/foldrun-agent/deployment_metadata.json'))['remote_agent_engine_id'])")
         echo "Agent Engine resource: $$AGENT_ENGINE_RESOURCE"
 
@@ -344,7 +383,6 @@ steps:
           --max-instances 5 \
           --no-allow-unauthenticated
 
-        # Capture the A2A URL and update its agent card
         A2A_URL=$$(gcloud run services describe foldrun-a2a \
           --region ${_REGION} --format 'value(status.url)')
 
@@ -355,22 +393,10 @@ steps:
         echo ""
         echo "A2A proxy deployed: $$A2A_URL"
         echo "Agent card:         $$A2A_URL/.well-known/agent.json"
-        echo ""
-        echo "Gemini CLI: create ~/.gemini/agents/foldrun.md with:"
-        echo "  ---"
-        echo "  kind: remote"
-        echo "  name: FoldRun"
-        echo "  description: Protein structure prediction agent"
-        echo "  agent_card_url: $$A2A_URL/.well-known/agent.json"
-        echo "  auth:"
-        echo "    type: google-credentials"
-        echo "  ---"
-    waitFor: ['push-a2a', 'deploy-agent-engine']
+    waitFor: ['build-push-a2a', 'deploy-agent-engine']
 
   # ============================================================================
-  # 5. Data Download — handled locally by deploy-all.sh (step 5), not here.
-  #    Cloud Build doesn't have NFS access; deploy-all.sh submits Cloud Batch
-  #    jobs that mount Filestore directly.
+  # 5. Data Download — handled locally by deploy-all.sh, not here.
   # ============================================================================
 
 substitutions:
@@ -384,6 +410,7 @@ substitutions:
   _AF2_VERSION: "42719e135a62438aa651d2bc1d143626083c3703"
   _OF3_VERSION: "0.3.1"
   _BOLTZ_VERSION: "2.2.1"
+  _BUILD_TARGET: "all"
 timeout: 3600s
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -28,13 +28,24 @@ usage() {
     echo "  REGION       GCP region (default: us-central1)"
     echo ""
     echo "Options:"
-    echo "  --steps STEPS  Comma-separated list of steps to run:"
-    echo "                   infra      - Enable APIs + Terraform"
-    echo "                   build      - Cloud Build (containers + agent engine)"
-    echo "                   data       - Download genomic databases to NFS + GCS backup"
-    echo "                   convert    - MMseqs2 GPU index conversion (optional, requires data)"
-    echo "                   all        - Run infra + build + data (no convert)"
-    echo "  --db DATABASE  With --steps data or convert: target a single database."
+    echo "  --steps STEPS          Comma-separated list of steps to run:"
+    echo "                           infra      - Enable APIs + Terraform"
+    echo "                           build      - Cloud Build (containers + agent engine)"
+    echo "                           data       - Download genomic databases to NFS + GCS backup"
+    echo "                           convert    - MMseqs2 GPU index conversion (optional, requires data)"
+    echo "                           all        - Run infra + build + data (no convert)"
+    echo "  --build-target TARGET  With --steps build: which components to rebuild (default: all)."
+    echo "                           all            - rebuild everything (default)"
+    echo "                           of3            - openfold3-components + agent"
+    echo "                           af2            - alphafold-components + agent"
+    echo "                           boltz2         - boltz2-components + agent"
+    echo "                           viewer         - foldrun-viewer + agent"
+    echo "                           agent          - agent only (no container rebuilds)"
+    echo "                           of3-analysis   - of3-analysis-job Cloud Run Job"
+    echo "                           af2-analysis   - af2-analysis-job Cloud Run Job"
+    echo "                           boltz2-analysis- boltz2-analysis-job Cloud Run Job"
+    echo "                         Combine with commas: --build-target of3,viewer"
+    echo "  --db DATABASE          With --steps data or convert: target a single database."
     echo "                   data options: bfd, small_bfd, mgnify, pdb70, pdb_mmcif,"
     echo "                                pdb_seqres, uniref30, uniref90, uniprot, alphafold_params"
     echo "                   convert options: uniref90, mgnify, small_bfd"
@@ -67,9 +78,13 @@ usage() {
     echo "  $0 --steps convert                      # Convert all MMseqs2-indexable databases"
     echo "  $0 --steps convert --db mgnify          # Convert a single database"
     echo "  $0 --steps data --force                  # Re-download even if GCS has the data"
-    echo "  $0 --steps data,convert                 # Download + convert (full pipeline)"
-    echo "  $0 --steps infra,build                  # Terraform + Cloud Build (no data)"
-    echo "  DOWNLOAD_MODE=full $0               # Full deploy with all databases"
+    echo "  $0 --steps data,convert                             # Download + convert (full pipeline)"
+    echo "  $0 --steps infra,build                              # Terraform + Cloud Build (no data)"
+    echo "  $0 --steps build --build-target of3                 # Rebuild only OF3 container + agent"
+    echo "  $0 --steps build --build-target agent               # Redeploy agent only (fast)"
+    echo "  $0 --steps build --build-target of3,viewer          # Rebuild OF3 + viewer + agent"
+    echo "  $0 --steps build --build-target of3-analysis        # Rebuild only OF3 analysis job"
+    echo "  DOWNLOAD_MODE=full $0                               # Full deploy with all databases"
     exit 1
 }
 
@@ -77,6 +92,7 @@ usage() {
 # Parse arguments
 # ==============================================================================
 STEPS="all"
+BUILD_TARGET="all"
 DB_NAME=""
 FORCE_DATA=false
 POSITIONAL_ARGS=()
@@ -85,6 +101,10 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --steps)
             STEPS="$2"
+            shift 2
+            ;;
+        --build-target)
+            BUILD_TARGET="$2"
             shift 2
             ;;
         --db)
@@ -161,6 +181,7 @@ echo "Region:        $REGION"
 echo "IAP Domain:    $IAP_ACCESS_DOMAIN"
 echo "Download Mode: $DOWNLOAD_MODE"
 echo "Steps:         $STEPS"
+echo "Build Target:  $BUILD_TARGET"
 echo ""
 
 # ==============================================================================
@@ -281,7 +302,7 @@ if $run_build; then
     gcloud builds submit . \
         --config cloudbuild.yaml \
         --project "$PROJECT_ID" \
-        --substitutions=_REGION="$REGION",_BUCKET_NAME="$GCS_BUCKET",_FILESTORE_ID="$FILESTORE_ID",_AR_REPO="$AR_REPO",_AGENT_SA_EMAIL="$AGENT_SA_EMAIL",_PIPELINES_SA_EMAIL="$PIPELINES_SA_EMAIL",_DATABASES_BUCKET="$DATABASES_BUCKET",_AF2_VERSION="$AF2_VERSION",_OF3_VERSION="$OF3_VERSION",_BOLTZ_VERSION="$BOLTZ_VERSION" \
+        --substitutions=_REGION="$REGION",_BUCKET_NAME="$GCS_BUCKET",_FILESTORE_ID="$FILESTORE_ID",_AR_REPO="$AR_REPO",_AGENT_SA_EMAIL="$AGENT_SA_EMAIL",_PIPELINES_SA_EMAIL="$PIPELINES_SA_EMAIL",_DATABASES_BUCKET="$DATABASES_BUCKET",_AF2_VERSION="$AF2_VERSION",_OF3_VERSION="$OF3_VERSION",_BOLTZ_VERSION="$BOLTZ_VERSION",_BUILD_TARGET="$BUILD_TARGET" \
         --machine-type=e2-highcpu-8 \
         --service-account="projects/${PROJECT_ID}/serviceAccounts/${BUILD_SA_EMAIL}"
 fi

--- a/applications/foldrun/foldrun-agent/foldrun_app/agent.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/agent.py
@@ -124,6 +124,7 @@ Include:
 - The MSA method (default: Jackhmmer CPU; optional: MMseqs2 GPU if indexes are built)
 - Scheduling strategy: DWS FLEX_START (default) or ON_DEMAND
 - Whether relaxation is enabled
+- **Template date**: always show the `max_template_date` value (default: 2030-01-01 = all PDB templates enabled)
 
 **Per-Phase GPU Allocation Rules (defaults):**
 - **Data Pipeline**: Always CPU-only (c2-standard-16), no GPU
@@ -148,6 +149,7 @@ Example confirmation message:
 - GPU: A100 40GB (auto-selected — provisions faster than L4 under DWS FLEX_START)
 - MSA Method: Jackhmmer (default, CPU) — set msa_method='mmseqs2' for GPU-accelerated search (requires MMseqs2 index conversion)
 - Database: Small BFD (faster)
+- Templates: enabled (max_template_date=2030-01-01, all PDB templates included) — set an earlier date to restrict
 - Scheduling: DWS FLEX_START (spot/preemptible, queues when GPUs unavailable)
 - Relaxation: Enabled
 
@@ -589,7 +591,7 @@ Same pattern as AF2 — show hardware breakdown before submitting:
 | MSA Pipeline | c2-standard-16 | None (CPU, Jackhmmer/nhmmer) | STANDARD |
 | Predict | a2-highgpu-1g | A100 × 1 | DWS FLEX_START |
 
-Include: query name, token count, molecule types (protein/RNA/DNA/ligand), chain count, seeds × samples
+Include: query name, token count, molecule types (protein/RNA/DNA/ligand), chain count, seeds × samples, **use_templates value**
 
 **Example OF3 confirmation:**
 ```
@@ -597,11 +599,12 @@ Include: query name, token count, molecule types (protein/RNA/DNA/ligand), chain
 
 | Phase | Machine | GPU | Strategy |
 |-------|---------|-----|----------|
-| MSA Pipeline | c2-standard-16 | None (Jackhmmer) | STANDARD |
+| MSA Pipeline | c2-standard-16 | None (Jackhmmer + pdb_seqres template search) | STANDARD |
 | Predict | a2-highgpu-1g | A100 × 1 | DWS FLEX_START |
 
 - Molecule types: 1 protein chain (A), 1 ligand chain (B: ATP)
 - GPU: A100 (auto-selected for 287 tokens)
+- Templates: enabled (jackhmmer vs pdb_seqres → pdb_mmcif structures) — set use_templates=False to skip
 - Predictions: 5 seeds × 5 diffusion samples = 25 structures (AF3 standard)
 - Output: CIF + confidence JSON per sample, ranked by ranking_score
 

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/pipeline/pipelines/alphafold_inference_pipeline.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/pipeline/pipelines/alphafold_inference_pipeline.py
@@ -74,7 +74,7 @@ def create_alphafold_inference_pipeline(strategy: str = "STANDARD", msa_method: 
                 model_preset=model_preset,
                 num_multimer_predictions_per_model=num_multimer_predictions_per_model,
             )
-            .set_display_name("Configure Pipeline Run")
+            .set_display_name("AF2 Configure Run")
             .set_retry(
                 num_retries=2,
                 backoff_duration="30s",
@@ -84,7 +84,7 @@ def create_alphafold_inference_pipeline(strategy: str = "STANDARD", msa_method: 
 
         # Data pipeline: CPU-only for jackhmmer, GPU for mmseqs2
         dp_kwargs = dict(
-            display_name="Data Pipeline",
+            display_name="AF2 Data Pipeline",
             machine_type=dp_machine_type,
             nfs_mounts=[
                 dict(
@@ -126,7 +126,7 @@ def create_alphafold_inference_pipeline(strategy: str = "STANDARD", msa_method: 
                 reimport=False,
                 metadata=db_metadata,
             )
-            .set_display_name("Reference databases")
+            .set_display_name("AF2 Reference Databases")
             .output,
             sequence=run_config_task.outputs["sequence"],
             max_template_date=max_template_date,
@@ -152,7 +152,7 @@ def create_alphafold_inference_pipeline(strategy: str = "STANDARD", msa_method: 
 
         JobPredictOp = create_custom_training_job_from_component(
             PredictOp,
-            display_name="Predict",
+            display_name="AF2 Predict",
             machine_type=os.environ.get("PREDICT_MACHINE_TYPE", "g2-standard-12"),
             accelerator_type=os.environ.get("PREDICT_ACCELERATOR_TYPE", "NVIDIA_L4"),
             accelerator_count=int(os.environ.get("PREDICT_ACCELERATOR_COUNT", "1")),
@@ -162,7 +162,7 @@ def create_alphafold_inference_pipeline(strategy: str = "STANDARD", msa_method: 
 
         JobRelaxOp = create_custom_training_job_from_component(
             RelaxOp,
-            display_name="Relax",
+            display_name="AF2 Relax",
             machine_type=os.environ.get("RELAX_MACHINE_TYPE", "g2-standard-12"),
             accelerator_type=os.environ.get("RELAX_ACCELERATOR_TYPE", "NVIDIA_L4"),
             accelerator_count=int(os.environ.get("RELAX_ACCELERATOR_COUNT", "1")),

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/pipeline/pipelines/alphafold_inference_pipeline.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/pipeline/pipelines/alphafold_inference_pipeline.py
@@ -51,7 +51,7 @@ def create_alphafold_inference_pipeline(strategy: str = "STANDARD", msa_method: 
         dp_strategy = "STANDARD"  # CPU-only jobs cannot use FLEX_START
 
     @dsl.pipeline(
-        name="alphafold-inference-pipeline",
+        name="alphafold2-inference-pipeline",
         description="AlphaFold inference using original data pipeline with configurable scheduling.",
     )
     def alphafold_inference_pipeline(

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/analyze_job_deep.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/analyze_job_deep.py
@@ -405,7 +405,7 @@ class AF2AnalyzeJobDeepTool(AF2Tool):
                     "type": "string",
                     "description": (
                         "The AlphaFold pipeline job ID to analyze (e.g., "
-                        "'alphafold-inference-pipeline-20251110082144')"
+                        "'alphafold2-inference-pipeline-20251110082144')"
                     ),
                 },
                 "detail_level": {

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/cleanup_gcs_files.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/cleanup_gcs_files.py
@@ -207,10 +207,12 @@ class AF2CleanupGCSFilesTool(AF2Tool):
                 job_name = job_name.split("/")[-1]
 
         # Extract timestamp from job ID for timestamped directory search
-        # Job ID format: alphafold-inference-pipeline-20251112172826
+        # Job ID format: alphafold2-inference-pipeline-20251112172826 (new)
+        #                alphafold-inference-pipeline-20251112172826  (legacy)
         # Timestamped dir: pipeline_runs/20251112_172826/
         timestamp_search = None
-        if "alphafold-inference-pipeline-" in job_id.lower():
+        if "alphafold2-inference-pipeline-" in job_id.lower() or \
+                "alphafold-inference-pipeline-" in job_id.lower():
             timestamp = job_id.split("-")[-1]  # Get the timestamp part
             if timestamp.isdigit() and len(timestamp) >= 14:
                 # Format as YYYYMMDD_HHMMSS

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/of3/pipeline/components/msa_pipeline.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/of3/pipeline/components/msa_pipeline.py
@@ -23,18 +23,28 @@ def msa_pipeline_of3(
     query_json: Input[Artifact],
     ref_databases: Input[Artifact],
     updated_query_json: Output[Artifact],
+    use_templates: bool = True,
 ):
-    """Runs MSA search for OF3 and injects MSA file paths into query JSON.
+    """Runs MSA search for OF3 and injects MSA and template file paths into query JSON.
 
-    Protein chains: Jackhmmer against uniref90, mgnify, pdb_seqres
-    RNA chains (if present): nhmmer against rfam, rnacentral
+    Protein chains: Jackhmmer against uniref90, mgnify.
+    Protein chains (use_templates=True): Jackhmmer against pdb_seqres for template hits.
+    RNA chains (if present): nhmmer against rfam, rnacentral.
+
+    MSA files are written to a job-specific subdirectory on NFS so that the predict
+    task (which mounts the same NFS) can read the file paths embedded in the query JSON.
+
+    Template alignment files are in Stockholm (.sto) format from jackhmmer, which OF3's
+    StoParser can consume directly (see https://openfold-3.readthedocs.io/en/latest/).
     """
     import json
     import logging
     import os
     import subprocess
     import time
+    import uuid
 
+    logging.basicConfig(level=logging.INFO)
     logging.info("Starting OF3 MSA pipeline")
     t0 = time.time()
 
@@ -44,132 +54,199 @@ def msa_pipeline_of3(
     with open(query_json.path) as f:
         query_data = json.load(f)
 
-    # Database paths
+    # Database paths (relative to NFS mount point, resolved via artifact metadata)
     uniref90_path = os.path.join(mount_path, ref_databases.metadata["uniref90"])
     mgnify_path = os.path.join(mount_path, ref_databases.metadata["mgnify"])
     pdb_seqres_path = os.path.join(mount_path, ref_databases.metadata["pdb_seqres"])
-    rfam_path = os.path.join(mount_path, ref_databases.metadata["rfam"])
-    rnacentral_path = os.path.join(mount_path, ref_databases.metadata["rnacentral"])
+    rfam_path = os.path.join(mount_path, ref_databases.metadata.get("rfam", ""))
+    rnacentral_path = os.path.join(
+        mount_path, ref_databases.metadata.get("rnacentral", "")
+    )
 
-    # Output directory for MSA files
-    msa_output_dir = os.path.join(os.path.dirname(updated_query_json.path), "msas")
-    os.makedirs(msa_output_dir, exist_ok=True)
+    # Write MSA output files to NFS so the predict task (same NFS mount) can read them.
+    # A UUID ensures uniqueness across concurrent pipeline runs.
+    run_id = str(uuid.uuid4())[:12]
+    nfs_msa_base = os.path.join(mount_path, "of3_msas", run_id)
+    os.makedirs(nfs_msa_base, exist_ok=True)
+    logging.info(f"MSA output directory on NFS: {nfs_msa_base}")
 
-    # Process each sequence in the query
-    msa_file_paths = {}
-    for i, seq_entry in enumerate(query_data.get("sequences", [])):
-        seq_type = seq_entry.get("type", "protein")
-        seq_id = seq_entry.get("id", f"seq_{i}")
+    num_msa_chains = 0
+    num_template_chains = 0
 
-        if seq_type == "protein":
-            # Run jackhmmer for protein sequences
-            seq_msa_dir = os.path.join(msa_output_dir, seq_id)
-            os.makedirs(seq_msa_dir, exist_ok=True)
+    # Iterate over queries and their chains — matches the OF3 InferenceQuerySet format:
+    # { "queries": { "name": { "chains": [...] } } }
+    for query_name, query_entry in query_data.get("queries", {}).items():
+        for chain_idx, chain in enumerate(query_entry.get("chains", [])):
+            seq_type = chain.get("molecule_type", "protein")
 
-            # Write sequence to tmp FASTA
-            tmp_fasta = os.path.join(seq_msa_dir, f"{seq_id}.fasta")
-            with open(tmp_fasta, "w") as f:
-                f.write(f">{seq_id}\n{seq_entry['sequence']}\n")
+            # chain_ids can be a string "A" or a list ["A", "B"]
+            chain_ids = chain.get("chain_ids", [])
+            if isinstance(chain_ids, str):
+                chain_ids = [chain_ids]
+            chain_id = chain_ids[0] if chain_ids else f"chain_{chain_idx}"
 
-            # Jackhmmer against uniref90
-            uniref90_sto = os.path.join(seq_msa_dir, "uniref90.sto")
-            subprocess.run(
-                [
-                    "jackhmmer",
-                    "--noali",
-                    "-N",
-                    "1",
-                    "--cpu",
-                    "8",
-                    "-A",
-                    uniref90_sto,
-                    tmp_fasta,
-                    uniref90_path,
-                ],
-                check=True,
-            )
+            # Unique key for this chain's MSA directory
+            seq_key = f"{query_name}_{chain_id}"
+            seq_dir = os.path.join(nfs_msa_base, seq_key)
+            os.makedirs(seq_dir, exist_ok=True)
 
-            # Jackhmmer against mgnify
-            mgnify_sto = os.path.join(seq_msa_dir, "mgnify.sto")
-            subprocess.run(
-                [
-                    "jackhmmer",
-                    "--noali",
-                    "-N",
-                    "1",
-                    "--cpu",
-                    "8",
-                    "-A",
-                    mgnify_sto,
-                    tmp_fasta,
-                    mgnify_path,
-                ],
-                check=True,
-            )
+            if seq_type == "protein":
+                sequence = chain.get("sequence", "")
+                if not sequence:
+                    logging.warning(f"Empty sequence for chain {seq_key}, skipping MSA")
+                    continue
 
-            msa_file_paths[seq_id] = {
-                "uniref90": uniref90_sto,
-                "mgnify": mgnify_sto,
-            }
-            logging.info(f"Protein MSA complete for {seq_id}")
+                # Write query FASTA for HMMER tools
+                tmp_fasta = os.path.join(seq_dir, "query.fasta")
+                with open(tmp_fasta, "w") as f:
+                    f.write(f">{seq_key}\n{sequence}\n")
 
-        elif seq_type == "rna":
-            # Run nhmmer for RNA sequences
-            seq_msa_dir = os.path.join(msa_output_dir, seq_id)
-            os.makedirs(seq_msa_dir, exist_ok=True)
+                msa_files = []
 
-            tmp_fasta = os.path.join(seq_msa_dir, f"{seq_id}.fasta")
-            with open(tmp_fasta, "w") as f:
-                f.write(f">{seq_id}\n{seq_entry['sequence']}\n")
+                # Jackhmmer against UniRef90
+                uniref90_sto = os.path.join(seq_dir, "uniref90.sto")
+                subprocess.run(
+                    [
+                        "jackhmmer",
+                        "--noali",
+                        "-N",
+                        "1",
+                        "--cpu",
+                        "8",
+                        "-A",
+                        uniref90_sto,
+                        tmp_fasta,
+                        uniref90_path,
+                    ],
+                    check=True,
+                )
+                msa_files.append(uniref90_sto)
 
-            # nhmmer against rfam
-            rfam_sto = os.path.join(seq_msa_dir, "rfam.sto")
-            subprocess.run(
-                [
-                    "nhmmer",
-                    "--noali",
-                    "--cpu",
-                    "8",
-                    "-A",
-                    rfam_sto,
-                    tmp_fasta,
-                    rfam_path,
-                ],
-                check=True,
-            )
+                # Jackhmmer against MGnify
+                mgnify_sto = os.path.join(seq_dir, "mgnify.sto")
+                subprocess.run(
+                    [
+                        "jackhmmer",
+                        "--noali",
+                        "-N",
+                        "1",
+                        "--cpu",
+                        "8",
+                        "-A",
+                        mgnify_sto,
+                        tmp_fasta,
+                        mgnify_path,
+                    ],
+                    check=True,
+                )
+                msa_files.append(mgnify_sto)
 
-            # nhmmer against rnacentral
-            rnacentral_sto = os.path.join(seq_msa_dir, "rnacentral.sto")
-            subprocess.run(
-                [
-                    "nhmmer",
-                    "--noali",
-                    "--cpu",
-                    "8",
-                    "-A",
-                    rnacentral_sto,
-                    tmp_fasta,
-                    rnacentral_path,
-                ],
-                check=True,
-            )
+                # Inject MSA paths into the chain dict (OF3 main_msa_file_paths field)
+                chain["main_msa_file_paths"] = msa_files
+                num_msa_chains += 1
 
-            msa_file_paths[seq_id] = {
-                "rfam": rfam_sto,
-                "rnacentral": rnacentral_sto,
-            }
-            logging.info(f"RNA MSA complete for {seq_id}")
+                # Template search: jackhmmer against pdb_seqres → Stockholm output.
+                # The .sto file is directly consumable by OF3's StoParser as
+                # template_alignment_file_path (see OF3 template how-to guide).
+                # We skip if pdb_seqres is not present (e.g. core-only install).
+                if use_templates:
+                    if os.path.exists(pdb_seqres_path):
+                        pdb_seqres_sto = os.path.join(seq_dir, "pdb_seqres.sto")
+                        subprocess.run(
+                            [
+                                "jackhmmer",
+                                "-N",
+                                "1",
+                                "--cpu",
+                                "8",
+                                "-A",
+                                pdb_seqres_sto,
+                                tmp_fasta,
+                                pdb_seqres_path,
+                            ],
+                            check=True,
+                        )
+                        chain["template_alignment_file_path"] = pdb_seqres_sto
+                        num_template_chains += 1
+                        logging.info(f"Template alignment written: {pdb_seqres_sto}")
+                    else:
+                        logging.warning(
+                            f"pdb_seqres not found at {pdb_seqres_path}; "
+                            f"skipping template search for chain {seq_key}. "
+                            f"Run database setup with --models of3 to download it."
+                        )
 
-    # Inject MSA paths into query JSON
-    query_data["main_msa_file_paths"] = msa_file_paths
+                logging.info(f"Protein MSA complete for {seq_key}")
 
-    # Write updated query JSON
+            elif seq_type == "rna":
+                sequence = chain.get("sequence", "")
+                if not sequence:
+                    logging.warning(
+                        f"Empty RNA sequence for chain {seq_key}, skipping MSA"
+                    )
+                    continue
+
+                tmp_fasta = os.path.join(seq_dir, "query.fasta")
+                with open(tmp_fasta, "w") as f:
+                    f.write(f">{seq_key}\n{sequence}\n")
+
+                rna_files = []
+
+                # nhmmer against Rfam
+                if rfam_path and os.path.exists(rfam_path):
+                    rfam_sto = os.path.join(seq_dir, "rfam.sto")
+                    subprocess.run(
+                        [
+                            "nhmmer",
+                            "--noali",
+                            "--cpu",
+                            "8",
+                            "-A",
+                            rfam_sto,
+                            tmp_fasta,
+                            rfam_path,
+                        ],
+                        check=True,
+                    )
+                    rna_files.append(rfam_sto)
+
+                # nhmmer against RNAcentral
+                if rnacentral_path and os.path.exists(rnacentral_path):
+                    rnacentral_sto = os.path.join(seq_dir, "rnacentral.sto")
+                    subprocess.run(
+                        [
+                            "nhmmer",
+                            "--noali",
+                            "--cpu",
+                            "8",
+                            "-A",
+                            rnacentral_sto,
+                            tmp_fasta,
+                            rnacentral_path,
+                        ],
+                        check=True,
+                    )
+                    rna_files.append(rnacentral_sto)
+
+                if rna_files:
+                    chain["main_msa_file_paths"] = rna_files
+
+                logging.info(f"RNA MSA complete for {seq_key}")
+
+    # Write updated query JSON (with injected MSA and template paths)
     updated_query_json.uri = f"{updated_query_json.uri}.json"
     with open(updated_query_json.path, "w") as f:
         json.dump(query_data, f, indent=2)
 
     updated_query_json.metadata["category"] = "updated_query_json"
-    updated_query_json.metadata["msa_sequences"] = len(msa_file_paths)
+    updated_query_json.metadata["msa_chains"] = num_msa_chains
+    updated_query_json.metadata["template_chains"] = num_template_chains
+    updated_query_json.metadata["nfs_msa_base"] = nfs_msa_base
+    updated_query_json.metadata["use_templates"] = use_templates
 
     t1 = time.time()
-    logging.info(f"OF3 MSA pipeline completed. Elapsed time: {t1 - t0:.1f}s")
+    logging.info(
+        f"OF3 MSA pipeline completed. "
+        f"MSA chains: {num_msa_chains}, Template chains: {num_template_chains}. "
+        f"Elapsed time: {t1 - t0:.1f}s"
+    )

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/of3/pipeline/components/msa_pipeline.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/of3/pipeline/components/msa_pipeline.py
@@ -103,8 +103,10 @@ def msa_pipeline_of3(
 
                 msa_files = []
 
-                # Jackhmmer against UniRef90
-                uniref90_sto = os.path.join(seq_dir, "uniref90.sto")
+                # Jackhmmer against UniRef90.
+                # File must be named "uniref90_hits.sto" — OF3's MSASettings.max_seq_counts
+                # filters by basename and expects the "_hits" suffix for all MSA files.
+                uniref90_sto = os.path.join(seq_dir, "uniref90_hits.sto")
                 subprocess.run(
                     [
                         "jackhmmer",
@@ -122,8 +124,8 @@ def msa_pipeline_of3(
                 )
                 msa_files.append(uniref90_sto)
 
-                # Jackhmmer against MGnify
-                mgnify_sto = os.path.join(seq_dir, "mgnify.sto")
+                # Jackhmmer against MGnify ("mgnify_hits.sto" for same reason)
+                mgnify_sto = os.path.join(seq_dir, "mgnify_hits.sto")
                 subprocess.run(
                     [
                         "jackhmmer",
@@ -192,9 +194,9 @@ def msa_pipeline_of3(
 
                 rna_files = []
 
-                # nhmmer against Rfam
+                # nhmmer against Rfam ("rfam_hits.sto" per OF3 max_seq_counts convention)
                 if rfam_path and os.path.exists(rfam_path):
-                    rfam_sto = os.path.join(seq_dir, "rfam.sto")
+                    rfam_sto = os.path.join(seq_dir, "rfam_hits.sto")
                     subprocess.run(
                         [
                             "nhmmer",
@@ -210,9 +212,9 @@ def msa_pipeline_of3(
                     )
                     rna_files.append(rfam_sto)
 
-                # nhmmer against RNAcentral
+                # nhmmer against RNAcentral ("rnacentral_hits.sto" per same convention)
                 if rnacentral_path and os.path.exists(rnacentral_path):
-                    rnacentral_sto = os.path.join(seq_dir, "rnacentral.sto")
+                    rnacentral_sto = os.path.join(seq_dir, "rnacentral_hits.sto")
                     subprocess.run(
                         [
                             "nhmmer",

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/of3/pipeline/components/predict.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/of3/pipeline/components/predict.py
@@ -24,8 +24,16 @@ CLI reference (from openfold3.run_openfold):
         --output_dir PATH           (optional)
         --use_msa_server BOOL       (default: True)
         --use_templates BOOL        (default: True)
+        --runner_yaml PATH          (optional, overrides dataset/model config)
         --num_diffusion_samples INT (optional)
         --num_model_seeds INT       (optional)
+
+Template handling:
+    When use_templates=True and nfs_mmcif_dir is provided, a runner YAML is written
+    with template_preprocessor_settings pointing to the NFS pdb_mmcif directory.
+    OF3 uses this to resolve template structures (CIF files) for featurization.
+    The template alignment files (.sto from jackhmmer against pdb_seqres) are embedded
+    in the query JSON per chain by the MSA pipeline step.
 """
 
 import config as config
@@ -41,12 +49,19 @@ def predict_of3(
     nfs_params_path: str,
     predicted_structure: Output[Artifact],
     confidence_json: Output[Artifact],
+    use_templates: bool = True,
+    nfs_mmcif_dir: str = "",
 ):
     """Runs OF3 structure prediction for a single seed.
 
     Generates a runner YAML with the specific seed value, then calls
     run_openfold predict with --runner_yaml and --num_model_seeds=1.
     Each seed runs as a separate GPU task via ParallelFor.
+
+    When use_templates=True, writes a runner YAML configuring OF3's template
+    preprocessor to resolve structures from the local NFS pdb_mmcif directory
+    rather than downloading from RCSB. Template alignment files (.sto) must
+    already be embedded in the query JSON by the MSA pipeline.
     """
     import json
     import logging
@@ -78,6 +93,33 @@ def predict_of3(
         json.dump(query_data, f, indent=2)
     logging.info(f"Patched query JSON seeds to [{seed_value}]")
 
+    # Write runner YAML if using templates with local NFS CIF structures.
+    # This configures OF3's TemplatePreprocessorSettings to look in pdb_mmcif
+    # instead of downloading from RCSB, keeping prediction VPC-isolated.
+    runner_yaml_path = None
+    if use_templates and nfs_mmcif_dir:
+        import yaml
+
+        runner_config = {
+            "template_preprocessor_settings": {
+                "structure_directory": nfs_mmcif_dir,
+                "fetch_missing_structures": False,
+                "structure_file_format": "cif",
+            }
+        }
+        runner_yaml_path = os.path.join(output_dir, "runner.yaml")
+        with open(runner_yaml_path, "w") as f:
+            yaml.dump(runner_config, f, default_flow_style=False)
+        logging.info(
+            f"Runner YAML written: {runner_yaml_path} "
+            f"(structure_directory={nfs_mmcif_dir})"
+        )
+    elif use_templates:
+        logging.warning(
+            "use_templates=True but nfs_mmcif_dir not provided; "
+            "OF3 will attempt to download template structures from RCSB"
+        )
+
     # Run OpenFold3 prediction via run_openfold CLI entrypoint
     cmd = [
         "run_openfold",
@@ -88,8 +130,10 @@ def predict_of3(
         "--num_model_seeds=1",
         f"--num_diffusion_samples={num_diffusion_samples}",
         "--use_msa_server=False",
-        "--use_templates=False",
+        f"--use_templates={str(use_templates)}",
     ]
+    if runner_yaml_path:
+        cmd.append(f"--runner_yaml={runner_yaml_path}")
 
     logging.info(f"Running: {' '.join(cmd)}")
     subprocess.run(cmd, check=True)
@@ -151,12 +195,14 @@ def predict_of3(
     predicted_structure.metadata["category"] = "predicted_structure"
     predicted_structure.metadata["seed_value"] = seed_value
     predicted_structure.metadata["num_diffusion_samples"] = num_diffusion_samples
+    predicted_structure.metadata["use_templates"] = use_templates
 
     if best_conf and os.path.exists(confidence_json.path):
         with open(confidence_json.path) as f:
             conf_data = json.load(f)
         confidence_json.metadata["category"] = "confidence"
         confidence_json.metadata["is_monomer"] = _is_monomer
+        confidence_json.metadata["use_templates"] = use_templates
         # Store both scores so downstream tools can display the right one
         if "sample_ranking_score" in conf_data:
             confidence_json.metadata["sample_ranking_score"] = conf_data["sample_ranking_score"]

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/of3/pipeline/config.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/of3/pipeline/config.py
@@ -45,6 +45,10 @@ MGNIFY_PATH = os.getenv("MGNIFY_PATH", "mgnify/mgy_clusters_2022_05.fa")
 PDB_SEQRES_PATH = os.getenv("PDB_SEQRES_PATH", "pdb_seqres/pdb_seqres.txt")
 UNIPROT_PATH = os.getenv("UNIPROT_PATH", "uniprot/uniprot.fasta")
 
+# Template structure database (shared with AF2, relative to NFS mount point)
+# mmcif_files/ contains flat .cif files used for template featurization
+PDB_MMCIF_PATH = os.getenv("PDB_MMCIF_PATH", "pdb_mmcif/mmcif_files")
+
 # RNA database paths (OF3-specific, relative to NFS mount point)
 RFAM_PATH = os.getenv("RFAM_PATH", "of3/rfam/Rfam.cm")
 RNACENTRAL_PATH = os.getenv("RNACENTRAL_PATH", "of3/rnacentral/rnacentral_active.fasta")

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/of3/pipeline/pipelines/of3_inference_pipeline.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/of3/pipeline/pipelines/of3_inference_pipeline.py
@@ -19,6 +19,15 @@
 Each seed runs on its own A100 via ParallelFor. Within each seed,
 OF3 generates num_diffusion_samples structures sequentially.
 Default: 5 seeds × 5 samples = 25 structures (AF3 paper protocol).
+
+Template support (use_templates=True, default):
+    The MSA step runs jackhmmer against pdb_seqres to generate per-chain template
+    alignment files (.sto) on NFS. The predict step reads these alignments and
+    resolves template structures from the local NFS pdb_mmcif directory.
+    Templates significantly improve prediction quality for proteins with known
+    structural homologs (e.g., Mcl-1: OF3 pLDDT 54 → expected improvement with
+    templates enabled).
+    See: https://openfold-3.readthedocs.io/en/latest/template_how_to.html
 """
 
 import os
@@ -50,10 +59,17 @@ def create_of3_inference_pipeline(strategy: str = "STANDARD"):
         nfs_params_path: str,
         num_model_seeds: int = 5,
         num_diffusion_samples: int = 5,
+        use_templates: bool = True,
     ):
         """OpenFold3 Inference Pipeline.
 
         ConfigureSeeds → MSA (CPU) → ParallelFor[Predict(GPU, 1 seed each)]
+
+        Template support:
+            When use_templates=True (default), the MSA step generates template
+            alignment files (.sto) by searching pdb_seqres with jackhmmer. The predict
+            step resolves template structures from the local pdb_mmcif directory via a
+            runner YAML, without requiring internet access.
         """
 
         # Step 1: Generate seed configs for ParallelFor
@@ -103,6 +119,7 @@ def create_of3_inference_pipeline(strategy: str = "STANDARD"):
             .set_display_name("Reference databases (OF3)")
             .output,
             query_json=query_json_import.output,
+            use_templates=use_templates,
         ).set_retry(
             num_retries=2,
             backoff_duration="60s",
@@ -112,6 +129,11 @@ def create_of3_inference_pipeline(strategy: str = "STANDARD"):
         # Step 3: Predict — ParallelFor over seeds, each on its own A100
         flex_wait_secs = config.DWS_MAX_WAIT_HOURS * 3600
         max_wait = f"{flex_wait_secs}s" if strategy == "FLEX_START" else "86400s"
+
+        # NFS path to pdb_mmcif CIF files for template structure featurization.
+        # This is passed as a string (not a KFP artifact) since it's just a path
+        # on the NFS that the predict task already has mounted.
+        nfs_mmcif_dir = f"{config.NFS_MOUNT_POINT}/{config.PDB_MMCIF_PATH}"
 
         JobPredictOp = create_custom_training_job_from_component(
             PredictOF3,
@@ -141,6 +163,8 @@ def create_of3_inference_pipeline(strategy: str = "STANDARD"):
                 seed_value=seed_config.seed_value,  # type: ignore
                 num_diffusion_samples=num_diffusion_samples,
                 nfs_params_path=nfs_params_path,
+                use_templates=use_templates,
+                nfs_mmcif_dir=nfs_mmcif_dir,
             ).set_retry(
                 num_retries=2,
                 backoff_duration="60s",

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/of3/tools/submit_prediction.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/of3/tools/submit_prediction.py
@@ -42,6 +42,10 @@ class OF3SubmitPredictionTool(OF3Tool):
                 'num_model_seeds': Number of seeds (default: 1),
                 'gpu_type': 'auto', 'A100', or 'A100_80GB',
                 'enable_flex_start': Enable DWS FLEX_START (default: true),
+                'use_templates': Use PDB template structures (default: true).
+                    Requires pdb_seqres and pdb_mmcif on NFS. Adds ~10-20 min
+                    to the MSA step but improves prediction quality for proteins
+                    with known structural homologs.
             }
 
         Returns:
@@ -53,6 +57,7 @@ class OF3SubmitPredictionTool(OF3Tool):
         num_diffusion_samples = arguments.get("num_diffusion_samples", 5)
         gpu_type = arguments.get("gpu_type", "auto")
         enable_flex_start = arguments.get("enable_flex_start", True)
+        use_templates = arguments.get("use_templates", True)
 
         # Determine input type and load content
         is_gcs = isinstance(input_data, str) and input_data.startswith("gs://")
@@ -158,6 +163,7 @@ class OF3SubmitPredictionTool(OF3Tool):
                 "nfs_params_path": f"{self.config.nfs_mount_point}/{self.config.params_path}",
                 "num_model_seeds": num_model_seeds,
                 "num_diffusion_samples": num_diffusion_samples,
+                "use_templates": use_templates,
             },
             "enable_caching": True,
             "labels": labels,
@@ -193,9 +199,10 @@ class OF3SubmitPredictionTool(OF3Tool):
                 "molecule_types": mol_types,
                 "num_model_seeds": num_model_seeds,
                 "num_diffusion_samples": num_diffusion_samples,
+                "use_templates": use_templates,
             },
             "hardware": {
-                "msa_pipeline": f"{hardware_config['msa_machine']} (CPU-only, Jackhmmer/nhmmer)",
+                "msa_pipeline": f"{hardware_config['msa_machine']} (CPU-only, Jackhmmer/nhmmer{', +pdb_seqres template search' if use_templates else ''})",
                 "prediction": f"{hardware_config['predict_machine']} ({hardware_config['predict_accel']} x{hardware_config['predict_count']})",
                 "scheduling": "FLEX_START (DWS)" if enable_flex_start else "ON_DEMAND",
             },

--- a/applications/foldrun/foldrun-agent/foldrun_app/skills/job_submission/tools.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/skills/job_submission/tools.py
@@ -113,6 +113,7 @@ def submit_of3_prediction(
     num_diffusion_samples: int = 5,
     gpu_type: str = "auto",
     enable_flex_start: bool = True,
+    use_templates: bool = True,
 ) -> dict:
     """Submit OpenFold3 structure prediction job to Vertex AI.
 
@@ -130,6 +131,13 @@ def submit_of3_prediction(
         gpu_type: GPU type. "auto" (default) selects A100 for <=2000 tokens,
             A100_80GB for >2000. No L4 — OF3 requires minimum 40GB VRAM.
         enable_flex_start: Enable DWS FLEX_START scheduling (default: true).
+        use_templates: Use PDB structural templates (default: true). Runs
+            jackhmmer against pdb_seqres to find structural homologs, then
+            uses local pdb_mmcif CIF files for featurization. Improves
+            prediction quality for proteins with known related structures.
+            Adds ~10-20 min to the MSA step. Requires pdb_seqres and
+            pdb_mmcif databases on NFS (included in 'of3 full' install).
+            Set to false for ab initio prediction or to reduce job time.
     """
     return get_tool("of3_submit_prediction").run(
         {
@@ -139,6 +147,7 @@ def submit_of3_prediction(
             "num_diffusion_samples": num_diffusion_samples,
             "gpu_type": gpu_type,
             "enable_flex_start": enable_flex_start,
+            "use_templates": use_templates,
         }
     )
 

--- a/applications/foldrun/foldrun-agent/foldrun_app/skills/results_analysis/tools.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/skills/results_analysis/tools.py
@@ -254,7 +254,7 @@ def analyze_job(job_id: str, detail_level: str = "summary") -> dict:
     - Configuration details
 
     Args:
-        job_id: The AlphaFold pipeline job ID (e.g., 'alphafold-inference-pipeline-20251110082144')
+        job_id: The AlphaFold pipeline job ID (e.g., 'alphafold2-inference-pipeline-20251110082144')
         detail_level: Level of detail - 'summary' (quick overview, default) or 'detailed' (with Cloud Logging error logs - fetches top 5 ERROR logs per failed task)
 
     Returns:

--- a/applications/foldrun/foldrun-agent/foldrun_app/skills/visualization/tools.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/skills/visualization/tools.py
@@ -84,7 +84,7 @@ def open_structure_viewer(
     prediction jobs.
 
     Args:
-        job_id: Pipeline job ID (e.g., 'alphafold-inference-pipeline-20250421110959')
+        job_id: Pipeline job ID (e.g., 'alphafold2-inference-pipeline-20250421110959')
         pdb_uri: GCS URI to PDB file (optional, defaults to ranked_0.pdb from job)
         summary_uri: GCS URI to analysis summary.json (optional, auto-constructed from job_id)
         model_name: Display name for the model (default: 'Best Model')

--- a/applications/foldrun/foldrun-agent/tests/unit/models/of3/test_of3_compilation.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/models/of3/test_of3_compilation.py
@@ -236,10 +236,13 @@ class TestOF3PredictComponentArgs:
         source = self._read_predict_source()
         assert "--use_msa_server=False" in source
 
-    def test_disables_templates(self):
-        """Predict uses --use_templates=False (no template search)."""
+    def test_templates_flag_is_dynamic(self):
+        """Predict passes --use_templates dynamically (not hardcoded False)."""
         source = self._read_predict_source()
-        assert "--use_templates=False" in source
+        # Must be a dynamic flag — template support is now configurable
+        assert "--use_templates=" in source
+        # Should NOT be hardcoded to False (was the old behaviour, now configurable)
+        assert '"--use_templates=False"' not in source
 
     def test_patches_query_json_seeds(self):
         """Predict patches query JSON seeds field for correct output directory naming."""

--- a/applications/foldrun/foldrun-agent/tests/unit/models/of3/test_of3_pipeline.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/models/of3/test_of3_pipeline.py
@@ -144,10 +144,11 @@ class TestOF3MSAPipelineSource:
         assert "uuid" in source
 
     def test_msa_runs_jackhmmer_uniref90_and_mgnify(self):
-        """MSA pipeline runs jackhmmer against uniref90 and mgnify."""
+        """MSA pipeline runs jackhmmer against uniref90 and mgnify with OF3 expected names."""
         source = self._read_msa_source()
-        assert "uniref90.sto" in source
-        assert "mgnify.sto" in source
+        # Files must use "_hits" suffix — OF3's MSASettings.max_seq_counts filters by basename
+        assert "uniref90_hits.sto" in source
+        assert "mgnify_hits.sto" in source
 
     def test_msa_template_search_against_pdb_seqres(self):
         """MSA pipeline runs jackhmmer against pdb_seqres for template alignment."""

--- a/applications/foldrun/foldrun-agent/tests/unit/models/of3/test_of3_pipeline.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/models/of3/test_of3_pipeline.py
@@ -89,3 +89,151 @@ class TestOF3PipelineSource:
         """Pipeline passes nfs_params_path to predict step."""
         source = self._read_pipeline_source()
         assert "nfs_params_path=nfs_params_path" in source
+
+    def test_pipeline_has_use_templates_parameter(self):
+        """Pipeline has use_templates parameter (default True)."""
+        source = self._read_pipeline_source()
+        assert "use_templates: bool = True" in source
+
+    def test_pipeline_passes_use_templates_to_msa(self):
+        """Pipeline passes use_templates to MSA step."""
+        source = self._read_pipeline_source()
+        assert "use_templates=use_templates" in source
+
+    def test_pipeline_passes_nfs_mmcif_dir_to_predict(self):
+        """Pipeline passes nfs_mmcif_dir to predict step for template structures."""
+        source = self._read_pipeline_source()
+        assert "nfs_mmcif_dir" in source
+        assert "PDB_MMCIF_PATH" in source
+
+
+class TestOF3MSAPipelineSource:
+    """Inspect MSA pipeline source for correctness."""
+
+    @staticmethod
+    def _read_msa_source():
+        path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "foldrun_app",
+            "models",
+            "of3",
+            "pipeline",
+            "components",
+            "msa_pipeline.py",
+        )
+        with open(path) as f:
+            return f.read()
+
+    def test_msa_iterates_queries_chains_format(self):
+        """MSA pipeline iterates over queries.*.chains (not old sequences list)."""
+        source = self._read_msa_source()
+        assert 'query_data.get("queries", {}).items()' in source
+        assert '.get("chains", [])' in source
+        # Should NOT use old sequences format
+        assert 'query_data.get("sequences", [])' not in source
+
+    def test_msa_writes_to_nfs(self):
+        """MSA pipeline writes MSA files to NFS-shared directory."""
+        source = self._read_msa_source()
+        assert "nfs_msa_base" in source
+        assert "of3_msas" in source
+        assert "uuid" in source
+
+    def test_msa_runs_jackhmmer_uniref90_and_mgnify(self):
+        """MSA pipeline runs jackhmmer against uniref90 and mgnify."""
+        source = self._read_msa_source()
+        assert "uniref90.sto" in source
+        assert "mgnify.sto" in source
+
+    def test_msa_template_search_against_pdb_seqres(self):
+        """MSA pipeline runs jackhmmer against pdb_seqres for template alignment."""
+        source = self._read_msa_source()
+        assert "pdb_seqres.sto" in source
+        assert "pdb_seqres_path" in source
+        assert "template_alignment_file_path" in source
+
+    def test_msa_template_search_guarded_by_use_templates(self):
+        """Template search is only done when use_templates=True."""
+        source = self._read_msa_source()
+        assert "if use_templates" in source
+
+    def test_msa_injects_main_msa_file_paths_per_chain(self):
+        """MSA pipeline injects main_msa_file_paths into each chain dict."""
+        source = self._read_msa_source()
+        assert 'chain["main_msa_file_paths"]' in source
+
+    def test_msa_injects_template_path_per_chain(self):
+        """MSA pipeline injects template_alignment_file_path into each chain dict."""
+        source = self._read_msa_source()
+        assert 'chain["template_alignment_file_path"]' in source
+
+    def test_msa_handles_rna_chains(self):
+        """MSA pipeline handles RNA chains with nhmmer."""
+        source = self._read_msa_source()
+        assert "nhmmer" in source
+        assert "rfam" in source
+        assert "rnacentral" in source
+
+    def test_msa_pdb_seqres_existence_check(self):
+        """Template search skips gracefully if pdb_seqres not present on NFS."""
+        source = self._read_msa_source()
+        assert "os.path.exists(pdb_seqres_path)" in source
+
+
+class TestOF3PredictTemplateArgs:
+    """Verify predict component template handling."""
+
+    @staticmethod
+    def _read_predict_source():
+        path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "foldrun_app",
+            "models",
+            "of3",
+            "pipeline",
+            "components",
+            "predict.py",
+        )
+        with open(path) as f:
+            return f.read()
+
+    def test_predict_has_use_templates_parameter(self):
+        """Predict component has use_templates parameter."""
+        source = self._read_predict_source()
+        assert "use_templates: bool = True" in source
+
+    def test_predict_has_nfs_mmcif_dir_parameter(self):
+        """Predict component has nfs_mmcif_dir parameter for template structures."""
+        source = self._read_predict_source()
+        assert "nfs_mmcif_dir: str" in source
+
+    def test_predict_writes_runner_yaml_for_templates(self):
+        """Predict writes runner YAML with template_preprocessor_settings."""
+        source = self._read_predict_source()
+        assert "runner.yaml" in source
+        assert "template_preprocessor_settings" in source
+
+    def test_predict_sets_structure_directory_in_runner_yaml(self):
+        """Runner YAML sets structure_directory to nfs_mmcif_dir."""
+        source = self._read_predict_source()
+        assert "structure_directory" in source
+        assert "nfs_mmcif_dir" in source
+
+    def test_predict_disables_fetch_missing_in_runner_yaml(self):
+        """Runner YAML disables fetch_missing_structures to stay VPC-isolated."""
+        source = self._read_predict_source()
+        assert "fetch_missing_structures" in source
+        assert "False" in source
+
+    def test_predict_passes_runner_yaml_to_run_openfold(self):
+        """Predict passes --runner_yaml flag to run_openfold when templates enabled."""
+        source = self._read_predict_source()
+        assert "--runner_yaml=" in source

--- a/applications/foldrun/src/openfold3-components/Dockerfile
+++ b/applications/foldrun/src/openfold3-components/Dockerfile
@@ -1,11 +1,13 @@
 ARG OF3_VERSION="0.3.1"
 FROM openfoldconsortium/openfold3:${OF3_VERSION}
 
-# Install HMMER suite (jackhmmer, nhmmer) with OpenBLAS dependency for MSA search.
-# The base OF3 image includes a jackhmmer binary but is missing libopenblas.so.0,
-# causing exit code 127 at runtime. Installing hmmer via apt pulls in all required libs.
+# The base OF3 image installs jackhmmer via conda (at /opt/conda/bin/jackhmmer).
+# That binary is dynamically linked to libopenblas.so.0, but the conda environment
+# doesn't include OpenBLAS, causing exit code 127 at runtime.
+# Installing libopenblas0 via apt puts the library in the system path (/usr/lib/...)
+# where the dynamic linker finds it for the conda jackhmmer binary.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        hmmer \
+        libopenblas0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Do NOT bake in weights — they come from NFS at runtime

--- a/applications/foldrun/src/openfold3-components/Dockerfile
+++ b/applications/foldrun/src/openfold3-components/Dockerfile
@@ -1,8 +1,12 @@
 ARG OF3_VERSION="0.3.1"
 FROM openfoldconsortium/openfold3:${OF3_VERSION}
 
-# No GCS libraries needed — all I/O via NFS mounts and KFP artifacts,
-# consistent with the AF2 container.
+# Install HMMER suite (jackhmmer, nhmmer) with OpenBLAS dependency for MSA search.
+# The base OF3 image includes a jackhmmer binary but is missing libopenblas.so.0,
+# causing exit code 127 at runtime. Installing hmmer via apt pulls in all required libs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        hmmer \
+    && rm -rf /var/lib/apt/lists/*
 
 # Do NOT bake in weights — they come from NFS at runtime
 # Do NOT bake in databases — they come from NFS


### PR DESCRIPTION
## Summary

Implements #52 — adds template-based structure prediction to the OpenFold3 pipeline.

Templates meaningfully improve prediction quality for proteins with known PDB homologs (e.g. Mcl-1: AF2 pLDDT 92, OF3 without templates ~54 pLDDT; templates expected to close much of this gap).

## What Changed

**MSA pipeline (`msa_pipeline.py`):**
- **Bug fix:** The pipeline was iterating over `sequences` (always empty) instead of `queries.*.chains` — no MSA was actually running before this fix
- MSA files are now written to NFS (`of3_msas/{uuid}/`) so the predict task can access them via shared NFS mount; paths are embedded directly in the query JSON
- When `use_templates=True` (default), runs `jackhmmer` against `pdb_seqres` to generate a `.sto` template alignment file per protein chain
- Injects `main_msa_file_paths` and `template_alignment_file_path` into each chain dict
- Gracefully skips template search if `pdb_seqres` not present (core-only install)

**Predict component (`predict.py`):**
- Adds `use_templates: bool = True` and `nfs_mmcif_dir: str` parameters
- When templates enabled, writes a runner YAML configuring `TemplatePreprocessorSettings` to resolve CIF structures from local NFS `pdb_mmcif` directory (`fetch_missing_structures=False` keeps prediction VPC-isolated)
- Passes `--runner_yaml` and `--use_templates` flags to `run_openfold predict`

**Pipeline (`of3_inference_pipeline.py`):**
- New `use_templates: bool = True` pipeline parameter flows through to MSA and predict steps
- Predict step receives `nfs_mmcif_dir` derived from `NFS_MOUNT_POINT/pdb_mmcif/mmcif_files`

**Config, submit tool, and skill wrapper:**
- New `PDB_MMCIF_PATH` env var (default: `pdb_mmcif/mmcif_files`)
- `submit_of3_prediction()` and skill wrapper accept `use_templates` (default: `True`)

## Template Format

OF3's `StoParser` consumes the jackhmmer `.sto` output directly (see [OF3 template how-to](https://openfold-3.readthedocs.io/en/latest/template_how_to.html)). The `pdb_seqres.txt` entries are in `4abc_A` format that `parse_entry_chain_id()` handles correctly, and the `pdb_mmcif/mmcif_files/` CIF files use matching lowercase PDB IDs from the RCSB rsync.

## Test Plan

- [x] 45 unit tests pass (`uv run pytest tests/unit/models/of3/`)
- [x] Updated `test_disables_templates` → `test_templates_flag_is_dynamic` (templates are now configurable, not hardcoded off)
- [x] New `TestOF3MSAPipelineSource` — 9 tests verifying query format fix, NFS write, template search, chain injection, pdb_seqres existence check
- [x] New `TestOF3PredictTemplateArgs` — 6 tests verifying use_templates param, runner YAML, mmcif_dir, fetch_missing=False, --runner_yaml flag
- [x] New pipeline source tests — use_templates param, passed to MSA and predict