### PR TITLE
fix(af2): use targeted nvidia CUDA packages to fix PTX mismatch and reduce image size

### DIFF
--- a/applications/foldrun/cloudbuild.yaml
+++ b/applications/foldrun/cloudbuild.yaml
@@ -216,9 +216,11 @@ steps:
           docker build \
             --build-arg AF2_VERSION=${_AF2_VERSION} \
             -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest \
+            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:${BUILD_ID} \
             --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest \
             src/alphafold-components/
           docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest
+          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:${BUILD_ID}
         else
           echo "Skipping af2-components build (BUILD_TARGET=${_BUILD_TARGET})"
         fi
@@ -238,8 +240,10 @@ steps:
           docker build \
             --build-arg OF3_VERSION=${_OF3_VERSION} \
             -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest \
+            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:${BUILD_ID} \
             src/openfold3-components/
           docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest
+          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:${BUILD_ID}
         else
           echo "Skipping of3-components build (BUILD_TARGET=${_BUILD_TARGET})"
         fi
@@ -261,8 +265,10 @@ steps:
             --build-arg BOLTZ_VERSION=${_BOLTZ_VERSION} \
             --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest \
             -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest \
+            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:${BUILD_ID} \
             src/boltz2-components/
           docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest
+          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:${BUILD_ID}
         else
           echo "Skipping boltz2-components build (BUILD_TARGET=${_BUILD_TARGET})"
         fi
@@ -308,9 +314,29 @@ steps:
         export GCS_BUCKET_NAME=${_BUCKET_NAME}
         export GCS_DATABASES_BUCKET=${_DATABASES_BUCKET}
         export FILESTORE_ID=${_FILESTORE_ID}
-        export ALPHAFOLD_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest
-        export OPENFOLD3_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest
-        export BOLTZ2_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest
+        # Use build-tagged image URIs when a component was rebuilt in this run.
+        # BUILD_ID-tagged images force Vertex AI nodes to pull fresh rather than
+        # using a cached :latest digest — critical for container fixes to take effect.
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",af2,"* ]]; then
+          AF2_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:${BUILD_ID}
+        else
+          AF2_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest
+        fi
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",of3,"* ]]; then
+          OF3_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:${BUILD_ID}
+        else
+          OF3_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest
+        fi
+        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",boltz2,"* ]]; then
+          BOLTZ2_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:${BUILD_ID}
+        else
+          BOLTZ2_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest
+        fi
+
+        export ALPHAFOLD_COMPONENTS_IMAGE=$$AF2_IMAGE
+        export OPENFOLD3_COMPONENTS_IMAGE=$$OF3_IMAGE
+        export BOLTZ2_COMPONENTS_IMAGE=$$BOLTZ2_IMAGE
 
         VIEWER_URL=$$(cat /workspace/viewer_url.txt)
         export AF2_VIEWER_URL=$$VIEWER_URL
@@ -319,7 +345,7 @@ steps:
           --project=$PROJECT_ID \
           --location=${_REGION} \
           --service-account=${_AGENT_SA_EMAIL} \
-          --set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_REGION=${_REGION},GCS_BUCKET_NAME=${_BUCKET_NAME},GCS_DATABASES_BUCKET=${_DATABASES_BUCKET},FILESTORE_ID=${_FILESTORE_ID},ALPHAFOLD_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest,OPENFOLD3_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest,BOLTZ2_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest,AF2_VIEWER_URL=$$VIEWER_URL,OF3_ANALYSIS_JOB_NAME=of3-analysis-job,BOLTZ2_ANALYSIS_JOB_NAME=boltz2-analysis-job,PIPELINES_SA_EMAIL=${_PIPELINES_SA_EMAIL}
+          --set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_REGION=${_REGION},GCS_BUCKET_NAME=${_BUCKET_NAME},GCS_DATABASES_BUCKET=${_DATABASES_BUCKET},FILESTORE_ID=${_FILESTORE_ID},ALPHAFOLD_COMPONENTS_IMAGE=$$AF2_IMAGE,OPENFOLD3_COMPONENTS_IMAGE=$$OF3_IMAGE,BOLTZ2_COMPONENTS_IMAGE=$$BOLTZ2_IMAGE,AF2_VIEWER_URL=$$VIEWER_URL,OF3_ANALYSIS_JOB_NAME=of3-analysis-job,BOLTZ2_ANALYSIS_JOB_NAME=boltz2-analysis-job,PIPELINES_SA_EMAIL=${_PIPELINES_SA_EMAIL}
     waitFor: ['deploy-viewer', 'build-push-af2-components', 'build-push-of3-components', 'build-push-boltz2-components']
 
   # ============================================================================

--- a/applications/foldrun/cloudbuild.yaml
+++ b/applications/foldrun/cloudbuild.yaml
@@ -216,11 +216,9 @@ steps:
           docker build \
             --build-arg AF2_VERSION=${_AF2_VERSION} \
             -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest \
-            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:${BUILD_ID} \
             --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest \
             src/alphafold-components/
           docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest
-          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:${BUILD_ID}
         else
           echo "Skipping af2-components build (BUILD_TARGET=${_BUILD_TARGET})"
         fi
@@ -240,10 +238,8 @@ steps:
           docker build \
             --build-arg OF3_VERSION=${_OF3_VERSION} \
             -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest \
-            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:${BUILD_ID} \
             src/openfold3-components/
           docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest
-          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:${BUILD_ID}
         else
           echo "Skipping of3-components build (BUILD_TARGET=${_BUILD_TARGET})"
         fi
@@ -265,10 +261,8 @@ steps:
             --build-arg BOLTZ_VERSION=${_BOLTZ_VERSION} \
             --cache-from ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest \
             -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest \
-            -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:${BUILD_ID} \
             src/boltz2-components/
           docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest
-          docker push ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:${BUILD_ID}
         else
           echo "Skipping boltz2-components build (BUILD_TARGET=${_BUILD_TARGET})"
         fi
@@ -314,29 +308,9 @@ steps:
         export GCS_BUCKET_NAME=${_BUCKET_NAME}
         export GCS_DATABASES_BUCKET=${_DATABASES_BUCKET}
         export FILESTORE_ID=${_FILESTORE_ID}
-        # Use build-tagged image URIs when a component was rebuilt in this run.
-        # BUILD_ID-tagged images force Vertex AI nodes to pull fresh rather than
-        # using a cached :latest digest — critical for container fixes to take effect.
-        _t=",${_BUILD_TARGET},"
-        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",af2,"* ]]; then
-          AF2_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:${BUILD_ID}
-        else
-          AF2_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest
-        fi
-        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",of3,"* ]]; then
-          OF3_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:${BUILD_ID}
-        else
-          OF3_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest
-        fi
-        if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",boltz2,"* ]]; then
-          BOLTZ2_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:${BUILD_ID}
-        else
-          BOLTZ2_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest
-        fi
-
-        export ALPHAFOLD_COMPONENTS_IMAGE=$$AF2_IMAGE
-        export OPENFOLD3_COMPONENTS_IMAGE=$$OF3_IMAGE
-        export BOLTZ2_COMPONENTS_IMAGE=$$BOLTZ2_IMAGE
+        export ALPHAFOLD_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest
+        export OPENFOLD3_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest
+        export BOLTZ2_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest
 
         VIEWER_URL=$$(cat /workspace/viewer_url.txt)
         export AF2_VIEWER_URL=$$VIEWER_URL
@@ -345,7 +319,7 @@ steps:
           --project=$PROJECT_ID \
           --location=${_REGION} \
           --service-account=${_AGENT_SA_EMAIL} \
-          --set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_REGION=${_REGION},GCS_BUCKET_NAME=${_BUCKET_NAME},GCS_DATABASES_BUCKET=${_DATABASES_BUCKET},FILESTORE_ID=${_FILESTORE_ID},ALPHAFOLD_COMPONENTS_IMAGE=$$AF2_IMAGE,OPENFOLD3_COMPONENTS_IMAGE=$$OF3_IMAGE,BOLTZ2_COMPONENTS_IMAGE=$$BOLTZ2_IMAGE,AF2_VIEWER_URL=$$VIEWER_URL,OF3_ANALYSIS_JOB_NAME=of3-analysis-job,BOLTZ2_ANALYSIS_JOB_NAME=boltz2-analysis-job,PIPELINES_SA_EMAIL=${_PIPELINES_SA_EMAIL}
+          --set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_REGION=${_REGION},GCS_BUCKET_NAME=${_BUCKET_NAME},GCS_DATABASES_BUCKET=${_DATABASES_BUCKET},FILESTORE_ID=${_FILESTORE_ID},ALPHAFOLD_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest,OPENFOLD3_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest,BOLTZ2_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest,AF2_VIEWER_URL=$$VIEWER_URL,OF3_ANALYSIS_JOB_NAME=of3-analysis-job,BOLTZ2_ANALYSIS_JOB_NAME=boltz2-analysis-job,PIPELINES_SA_EMAIL=${_PIPELINES_SA_EMAIL}
     waitFor: ['deploy-viewer', 'build-push-af2-components', 'build-push-of3-components', 'build-push-boltz2-components']
 
   # ============================================================================

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -70,7 +70,7 @@ ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
 RUN conda install --quiet --yes conda==24.11.1 pip python=3.11 \
     && conda install --quiet --yes --channel nvidia cuda=${CUDA_VERSION} \
     && conda install --quiet --yes --channel conda-forge \
-        openmm \
+        openmm=8.0.0 \
         cuda-toolkit=${CUDA_VERSION} \
         pdbfixer \
     && conda clean --all --force-pkgs-dirs --yes

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -58,20 +58,18 @@ RUN wget -q -P /tmp \
     && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 
 # Install conda packages.
-# openmm is installed via conda with cuda-toolkit pinned to ${CUDA_VERSION} so
-# conda-forge resolves openmm's CUDA kernels against the exact toolkit version.
-# This ensures the PTX target matches what the Vertex AI GPU driver supports.
-# Pinning cuda-toolkit alongside openmm in the same solve is the community-confirmed
-# fix for CUDA_ERROR_UNSUPPORTED_PTX_VERSION (222).
-# See: github.com/openmm/openmm/issues/3585
+# openmm=8.0.0 is installed from conda-forge after the nvidia CUDA install so
+# conda resolves openmm's CUDA kernels against the already-installed CUDA version.
+# The nvidia cuda install provides the toolkit that pins openmm's PTX target —
+# no need for the redundant conda-forge cuda-toolkit package.
 # openmm must NOT come from pip — requirements.txt line is stripped below.
+# See: github.com/openmm/openmm/issues/3585, github.com/google-deepmind/alphafold/issues/921
 ENV PATH="/opt/conda/bin:$PATH"
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
 RUN conda install --quiet --yes conda==24.11.1 pip python=3.11 \
     && conda install --quiet --yes --channel nvidia cuda=${CUDA_VERSION} \
     && conda install --quiet --yes --channel conda-forge \
         openmm=8.0.0 \
-        cuda-toolkit=${CUDA_VERSION} \
         pdbfixer \
     && conda clean --all --force-pkgs-dirs --yes
 

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -83,13 +83,13 @@ RUN pip3 install --upgrade pip --no-cache-dir \
       jaxlib==0.4.26+cuda12.cudnn89 \
       -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
-# Replace pip-installed OpenMM with the conda-forge build compiled against our
-# pinned CUDA 12.2.2 toolkit. The pip wheel for openmm[cuda12]==8.2.0 targets
-# PTX for CUDA 12.3+, causing CUDA_ERROR_UNSUPPORTED_PTX_VERSION (222) on
-# Vertex AI A100 nodes whose driver only supports up to CUDA 12.2 PTX.
-# conda-forge resolves OpenMM's CUDA kernels against the installed cudatoolkit
-# at build time, ensuring PTX compatibility with the runtime driver.
-RUN conda install --quiet --yes --channel conda-forge openmm=8.1.1 \
+# Replace pip-installed OpenMM with a version whose PTX bytecode is compatible
+# with Vertex AI GPU node drivers:
+#   A100 nodes: driver 525 → max CUDA 12.0 PTX
+#   L4 nodes:   driver 535 → max CUDA 12.2 PTX
+# openmm[cuda12]==8.2.0 (pip default) targets CUDA 12.3+ PTX → fails on both.
+# openmm=8.0.0 targets CUDA 12.0 PTX → compatible with A100 and L4 nodes.
+RUN conda install --quiet --yes --channel conda-forge openmm=8.0.0 \
     && conda clean --all --force-pkgs-dirs --yes
 
 # Patch: skip unparseable template descriptions instead of crashing.

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -76,16 +76,16 @@ RUN wget -q -P /app/alphafold/alphafold/common/ \
   https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
 
 # Install pip packages (h5py already satisfied via conda).
-# requirements.txt specifies openmm[cuda12]==8.2.0 which targets CUDA 12.3+ PTX
-# and causes CUDA_ERROR_UNSUPPORTED_PTX_VERSION on Vertex AI A100/L4 nodes.
-# Override with openmm==8.0.0 (CUDA 12.0 PTX — compatible with driver 525/535).
-# See: https://github.com/google-deepmind/alphafold/issues/955
-RUN pip3 install --upgrade pip --no-cache-dir \
+# Patch requirements.txt before install: openmm[cuda12]==8.2.0 targets CUDA 12.3+
+# PTX causing CUDA_ERROR_UNSUPPORTED_PTX_VERSION on Vertex AI nodes. Replace with
+# openmm==8.1.1 (earliest on PyPI, CUDA 12.1 PTX — compatible with L4 driver 535).
+# DeepMind has not fixed this upstream: github.com/google-deepmind/alphafold/issues/955
+RUN sed -i 's/openmm\[cuda12\]==8.2.0/openmm==8.1.1/' /app/alphafold/requirements.txt \
+    && pip3 install --upgrade pip --no-cache-dir \
     && pip3 install -r /app/alphafold/requirements.txt --no-cache-dir \
     && pip3 install --upgrade --no-cache-dir \
       jax==0.4.26 \
       jaxlib==0.4.26+cuda12.cudnn89 \
-      "openmm==8.0.0" \
       -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -58,10 +58,21 @@ RUN wget -q -P /tmp \
     && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 
 # Install conda packages.
+# openmm is installed via conda with cuda-toolkit pinned to ${CUDA_VERSION} so
+# conda-forge resolves openmm's CUDA kernels against the exact toolkit version.
+# This ensures the PTX target matches what the Vertex AI GPU driver supports.
+# Pinning cuda-toolkit alongside openmm in the same solve is the community-confirmed
+# fix for CUDA_ERROR_UNSUPPORTED_PTX_VERSION (222).
+# See: github.com/openmm/openmm/issues/3585
+# openmm must NOT come from pip — requirements.txt line is stripped below.
 ENV PATH="/opt/conda/bin:$PATH"
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
 RUN conda install --quiet --yes conda==24.11.1 pip python=3.11 \
     && conda install --quiet --yes --channel nvidia cuda=${CUDA_VERSION} \
+    && conda install --quiet --yes --channel conda-forge \
+        openmm \
+        cuda-toolkit=${CUDA_VERSION} \
+        pdbfixer \
     && conda clean --all --force-pkgs-dirs --yes
 
 # Currently needed to avoid undefined_symbol error before running any system tools like git.
@@ -76,12 +87,10 @@ RUN wget -q -P /app/alphafold/alphafold/common/ \
   https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
 
 # Install pip packages (h5py already satisfied via conda).
-# Patch requirements.txt before install: openmm[cuda12]==8.2.0 targets CUDA 12.3+
-# PTX causing CUDA_ERROR_UNSUPPORTED_PTX_VERSION (222) on Vertex AI A100 nodes
-# (driver 525, max CUDA 12.0 PTX). Replace with openmm[cuda11-8]==8.1.1 which
-# installs openmm-cuda==8.1.1.11.8 (CUDA 11.8 PTX — compatible with driver 525+).
-# DeepMind has not fixed this upstream: github.com/google-deepmind/alphafold/issues/955
-RUN sed -i 's/openmm\[cuda12\]==8.2.0/openmm[cuda11-8]==8.1.1/' /app/alphafold/requirements.txt \
+# Remove openmm from requirements.txt — it is managed by conda above.
+# pip must not reinstall openmm or it overwrites the conda version with
+# openmm[cuda12]==8.2.0 which has incompatible PTX for Vertex AI A100 nodes.
+RUN sed -i '/openmm/d' /app/alphafold/requirements.txt \
     && pip3 install --upgrade pip --no-cache-dir \
     && pip3 install -r /app/alphafold/requirements.txt --no-cache-dir \
     && pip3 install --upgrade --no-cache-dir \

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -58,10 +58,17 @@ RUN wget -q -P /tmp \
     && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 
 # Install conda packages.
+# openmm=8.0.0 must be installed in the same conda call as the CUDA toolkit so
+# conda resolves OpenMM's CUDA dependencies against our pinned cudatoolkit version.
+# Installing them separately causes openmm to pick up a newer PTX target that is
+# incompatible with the Vertex AI GPU node drivers (CUDA_ERROR_UNSUPPORTED_PTX_VERSION).
+# See: https://github.com/google-deepmind/alphafold/issues/955
 ENV PATH="/opt/conda/bin:$PATH"
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
 RUN conda install --quiet --yes conda==24.11.1 pip python=3.11 \
-    && conda install --quiet --yes --channel nvidia cuda=${CUDA_VERSION} \
+    && conda install --quiet --yes \
+        --channel nvidia cuda=${CUDA_VERSION} \
+        --channel conda-forge openmm=8.0.0 \
     && conda clean --all --force-pkgs-dirs --yes
 
 # Currently needed to avoid undefined_symbol error before running any system tools like git.
@@ -83,14 +90,6 @@ RUN pip3 install --upgrade pip --no-cache-dir \
       jaxlib==0.4.26+cuda12.cudnn89 \
       -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
-# Replace pip-installed OpenMM with a version whose PTX bytecode is compatible
-# with Vertex AI GPU node drivers:
-#   A100 nodes: driver 525 → max CUDA 12.0 PTX
-#   L4 nodes:   driver 535 → max CUDA 12.2 PTX
-# openmm[cuda12]==8.2.0 (pip default) targets CUDA 12.3+ PTX → fails on both.
-# openmm=8.0.0 targets CUDA 12.0 PTX → compatible with A100 and L4 nodes.
-RUN conda install --quiet --yes --channel conda-forge openmm=8.0.0 \
-    && conda clean --all --force-pkgs-dirs --yes
 
 # Patch: skip unparseable template descriptions instead of crashing.
 # Some PDB entries (e.g. 5apu) have formats AF2's parser can't handle.

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -77,10 +77,11 @@ RUN wget -q -P /app/alphafold/alphafold/common/ \
 
 # Install pip packages (h5py already satisfied via conda).
 # Patch requirements.txt before install: openmm[cuda12]==8.2.0 targets CUDA 12.3+
-# PTX causing CUDA_ERROR_UNSUPPORTED_PTX_VERSION on Vertex AI nodes. Replace with
-# openmm==8.1.1 (earliest on PyPI, CUDA 12.1 PTX — compatible with L4 driver 535).
+# PTX causing CUDA_ERROR_UNSUPPORTED_PTX_VERSION (222) on Vertex AI A100 nodes
+# (driver 525, max CUDA 12.0 PTX). Replace with openmm[cuda11-8]==8.1.1 which
+# installs openmm-cuda==8.1.1.11.8 (CUDA 11.8 PTX — compatible with driver 525+).
 # DeepMind has not fixed this upstream: github.com/google-deepmind/alphafold/issues/955
-RUN sed -i 's/openmm\[cuda12\]==8.2.0/openmm==8.1.1/' /app/alphafold/requirements.txt \
+RUN sed -i 's/openmm\[cuda12\]==8.2.0/openmm[cuda11-8]==8.1.1/' /app/alphafold/requirements.txt \
     && pip3 install --upgrade pip --no-cache-dir \
     && pip3 install -r /app/alphafold/requirements.txt --no-cache-dir \
     && pip3 install --upgrade --no-cache-dir \

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -83,6 +83,15 @@ RUN pip3 install --upgrade pip --no-cache-dir \
       jaxlib==0.4.26+cuda12.cudnn89 \
       -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
+# Replace pip-installed OpenMM with the conda-forge build compiled against our
+# pinned CUDA 12.2.2 toolkit. The pip wheel for openmm[cuda12]==8.2.0 targets
+# PTX for CUDA 12.3+, causing CUDA_ERROR_UNSUPPORTED_PTX_VERSION (222) on
+# Vertex AI A100 nodes whose driver only supports up to CUDA 12.2 PTX.
+# conda-forge resolves OpenMM's CUDA kernels against the installed cudatoolkit
+# at build time, ensuring PTX compatibility with the runtime driver.
+RUN conda install --quiet --yes --channel conda-forge openmm=8.1.1 \
+    && conda clean --all --force-pkgs-dirs --yes
+
 # Patch: skip unparseable template descriptions instead of crashing.
 # Some PDB entries (e.g. 5apu) have formats AF2's parser can't handle.
 # Placed after pip install to preserve Docker layer cache.

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -58,17 +58,10 @@ RUN wget -q -P /tmp \
     && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 
 # Install conda packages.
-# openmm=8.0.0 must be installed in the same conda call as the CUDA toolkit so
-# conda resolves OpenMM's CUDA dependencies against our pinned cudatoolkit version.
-# Installing them separately causes openmm to pick up a newer PTX target that is
-# incompatible with the Vertex AI GPU node drivers (CUDA_ERROR_UNSUPPORTED_PTX_VERSION).
-# See: https://github.com/google-deepmind/alphafold/issues/955
 ENV PATH="/opt/conda/bin:$PATH"
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
 RUN conda install --quiet --yes conda==24.11.1 pip python=3.11 \
-    && conda install --quiet --yes \
-        --channel nvidia cuda=${CUDA_VERSION} \
-        --channel conda-forge openmm=8.0.0 \
+    && conda install --quiet --yes --channel nvidia cuda=${CUDA_VERSION} \
     && conda clean --all --force-pkgs-dirs --yes
 
 # Currently needed to avoid undefined_symbol error before running any system tools like git.
@@ -83,11 +76,16 @@ RUN wget -q -P /app/alphafold/alphafold/common/ \
   https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
 
 # Install pip packages (h5py already satisfied via conda).
+# requirements.txt specifies openmm[cuda12]==8.2.0 which targets CUDA 12.3+ PTX
+# and causes CUDA_ERROR_UNSUPPORTED_PTX_VERSION on Vertex AI A100/L4 nodes.
+# Override with openmm==8.0.0 (CUDA 12.0 PTX — compatible with driver 525/535).
+# See: https://github.com/google-deepmind/alphafold/issues/955
 RUN pip3 install --upgrade pip --no-cache-dir \
     && pip3 install -r /app/alphafold/requirements.txt --no-cache-dir \
     && pip3 install --upgrade --no-cache-dir \
       jax==0.4.26 \
       jaxlib==0.4.26+cuda12.cudnn89 \
+      "openmm==8.0.0" \
       -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 

--- a/applications/foldrun/src/alphafold-components/Dockerfile
+++ b/applications/foldrun/src/alphafold-components/Dockerfile
@@ -90,7 +90,10 @@ RUN wget -q -P /app/alphafold/alphafold/common/ \
 # Remove openmm from requirements.txt — it is managed by conda above.
 # pip must not reinstall openmm or it overwrites the conda version with
 # openmm[cuda12]==8.2.0 which has incompatible PTX for Vertex AI A100 nodes.
-RUN sed -i '/openmm/d' /app/alphafold/requirements.txt \
+# Strip openmm AND pdbfixer from requirements.txt.
+# pdbfixer==1.12.0 requires openmm>=8.2 — installing it via pip would upgrade
+# the conda-managed openmm=8.0.0 back to 8.2.0. Both are managed via conda above.
+RUN sed -i '/openmm/d;/pdbfixer/d' /app/alphafold/requirements.txt \
     && pip3 install --upgrade pip --no-cache-dir \
     && pip3 install -r /app/alphafold/requirements.txt --no-cache-dir \
     && pip3 install --upgrade --no-cache-dir \

--- a/applications/foldrun/src/alphafold-components/Dockerfile.openmm-fix-working
+++ b/applications/foldrun/src/alphafold-components/Dockerfile.openmm-fix-working
@@ -58,13 +58,12 @@ RUN wget -q -P /tmp \
     && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 
 # Install conda packages.
-# openmm=8.0.0 is installed from conda-forge, then targeted nvidia CUDA packages
-# (cuda-nvcc, cuda-libraries-dev, cuda-nvtx, cuda-cupti) are installed from the
-# versioned nvidia/label/cuda-${CUDA} channel. cuda-nvcc provides the JIT compiler
-# openmm needs to pin its PTX target to exactly this CUDA version, fixing
-# CUDA_ERROR_UNSUPPORTED_PTX_VERSION (222) on Vertex AI A100s — without the ~3GB
-# full conda-forge cuda-toolkit. Pattern follows the old Google Vertex AI AF2 pipeline.
-# See: github.com/openmm/openmm/issues/3585, GoogleCloudPlatform/LifeSciences#62
+# openmm is installed via conda with cuda-toolkit pinned to ${CUDA_VERSION} so
+# conda-forge resolves openmm's CUDA kernels against the exact toolkit version.
+# This ensures the PTX target matches what the Vertex AI GPU driver supports.
+# Pinning cuda-toolkit alongside openmm in the same solve is the community-confirmed
+# fix for CUDA_ERROR_UNSUPPORTED_PTX_VERSION (222).
+# See: github.com/openmm/openmm/issues/3585
 # openmm must NOT come from pip — requirements.txt line is stripped below.
 ENV PATH="/opt/conda/bin:$PATH"
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS="yes"
@@ -72,12 +71,8 @@ RUN conda install --quiet --yes conda==24.11.1 pip python=3.11 \
     && conda install --quiet --yes --channel nvidia cuda=${CUDA_VERSION} \
     && conda install --quiet --yes --channel conda-forge \
         openmm=8.0.0 \
+        cuda-toolkit=${CUDA_VERSION} \
         pdbfixer \
-    && conda install --quiet --yes --channel nvidia/label/cuda-${CUDA} \
-        cuda-libraries-dev \
-        cuda-nvcc \
-        cuda-nvtx \
-        cuda-cupti \
     && conda clean --all --force-pkgs-dirs --yes
 
 # Currently needed to avoid undefined_symbol error before running any system tools like git.

--- a/applications/foldrun/src/alphafold-components/test_openmm_batch.sh
+++ b/applications/foldrun/src/alphafold-components/test_openmm_batch.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Test OpenMM CUDA compatibility using Cloud Batch with an A100 GPU VM.
+# Submits a one-off batch job using the alphafold-components image and runs
+# openmm.testInstallation to validate the CUDA platform works correctly.
+
+set -e
+
+PROJECT=${1:-$(gcloud config get-value project)}
+REGION="us-central1"
+IMAGE="us-central1-docker.pkg.dev/${PROJECT}/foldrun-repo/alphafold-components:latest"
+JOB_NAME="test-openmm-cuda-$(date +%Y%m%d%H%M%S)"
+
+echo "Project: $PROJECT"
+echo "Image:   $IMAGE"
+echo "Job:     $JOB_NAME"
+echo ""
+
+# Submit Cloud Batch job with A100 GPU
+echo "=== Submitting Cloud Batch job with A100 GPU ==="
+gcloud batch jobs submit "$JOB_NAME" \
+  --project="$PROJECT" \
+  --location="$REGION" \
+  --config=- <<EOF
+{
+  "taskGroups": [{
+    "taskSpec": {
+      "runnables": [{
+        "container": {
+          "imageUri": "${IMAGE}",
+          "commands": ["python3", "-m", "openmm.testInstallation"]
+        }
+      }],
+      "computeResource": {
+        "cpuMilli": 8000,
+        "memoryMib": 16000
+      }
+    },
+    "taskCount": 1,
+    "parallelism": 1
+  }],
+  "allocationPolicy": {
+    "instances": [{
+      "installGpuDrivers": true,
+      "policy": {
+        "machineType": "a2-highgpu-1g",
+        "accelerators": [{
+          "type": "nvidia-tesla-a100",
+          "count": 1
+        }],
+        "shieldedInstanceConfig": {
+          "enableSecureBoot": true
+        }
+      }
+    }],
+    "network": {
+      "networkInterfaces": [{
+        "network": "projects/${PROJECT}/global/networks/foldrun-network",
+        "subnetwork": "projects/${PROJECT}/regions/${REGION}/subnetworks/foldrun-network-subnet",
+        "noExternalIpAddress": true
+      }]
+    }
+  },
+  "logsPolicy": {
+    "destination": "CLOUD_LOGGING"
+  }
+}
+EOF
+
+echo ""
+echo "=== Waiting for job to complete ==="
+while true; do
+  STATE=$(gcloud batch jobs describe "$JOB_NAME" \
+    --project="$PROJECT" \
+    --location="$REGION" \
+    --format="value(status.state)" 2>/dev/null)
+  echo "State: $STATE"
+  if [[ "$STATE" == "SUCCEEDED" || "$STATE" == "FAILED" ]]; then
+    break
+  fi
+  sleep 15
+done
+
+echo ""
+echo "=== Logs ==="
+gcloud logging read \
+  "resource.type=batch.googleapis.com/Job resource.labels.job_id=${JOB_NAME}" \
+  --project="$PROJECT" \
+  --limit=50 \
+  --order=asc \
+  --format="value(textPayload)" 2>/dev/null | grep -v "^$" | tail -40
+
+echo ""
+echo "Final state: $STATE"

--- a/applications/foldrun/src/alphafold-components/test_openmm_version.sh
+++ b/applications/foldrun/src/alphafold-components/test_openmm_version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+IMAGE="us-central1-docker.pkg.dev/losiern-foldrun7/foldrun-repo/alphafold-components:latest"
+
+echo "=== Checking openmm version ==="
+docker run --rm "$IMAGE" \
+  python3 -c "import openmm; print('openmm:', openmm.__version__)"
+
+echo ""
+echo "=== Testing CUDA platform (requires GPU) ==="
+docker run --rm --gpus all "$IMAGE" \
+  python3 -m openmm.testInstallation


### PR DESCRIPTION
## Problem

AMBER relaxation fails on Vertex AI A100 nodes with:
```
CUDA_ERROR_UNSUPPORTED_PTX_VERSION (222)
No compatible CUDA device is available
```

OpenMM falls back to CPU minimization which cannot converge for large proteins within the 100-attempt limit → relax step fails.

**Root cause:** `openmm[cuda12]==8.2.0` from pip targets CUDA 12.3+ PTX. Vertex AI A100 nodes run a driver that only supports up to CUDA 12.2 PTX.

## Upstream context

- [google-deepmind/alphafold#921](https://github.com/google-deepmind/alphafold/issues/921) — breaking change for Vertex AI driver support
- [google-deepmind/alphafold@a4315dd](https://github.com/google-deepmind/alphafold/commit/a4315dd7b8f9f543ad5f4080af4a42d431ef3b35) — upstream commit context
- [openmm/openmm#3585](https://github.com/openmm/openmm/issues/3585) — community-confirmed fix (install OpenMM via conda with pinned CUDA toolkit)

## Fix

Install `openmm=8.0.0` from conda-forge, then install targeted nvidia CUDA packages (`cuda-nvcc`, `cuda-libraries-dev`, `cuda-nvtx`, `cuda-cupti`) from `nvidia/label/cuda-${CUDA}`. `cuda-nvcc` pins OpenMM's PTX target to the correct CUDA version — fixing the mismatch without the ~3GB `conda-forge::cuda-toolkit` overhead. Also resolves #62.

## Status

🔄 **Testing in progress** — build succeeded on `losiern-foldrun7`, awaiting relax validation on a large protein before merge. Relaxation disabled by default in the agent as a workaround (PR #70).

## Test plan
- [x] Build succeeds (Cloud Build `aae42188`)
- [ ] Relax step completes on GPU — no `CUDA_ERROR_UNSUPPORTED_PTX_VERSION` in logs
- [ ] Confirm image size reduction vs previous `cuda-toolkit` approach