### PR TITLE
feat(foldrun): add API warm-up between infra and build steps

### DIFF
--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -283,9 +283,43 @@ EOF
 fi
 
 # ==============================================================================
+# Helper: API warm-up — polls required APIs until they respond, or times out.
+# Runs automatically between infra and build on a fresh project. Safe no-op on
+# existing projects where APIs are already initialized. Refs: issue #65
+# ==============================================================================
+warm_up_apis() {
+    echo ""
+    echo "Warming up GCP APIs (may take 1-3 min on a new project)..."
+    local timeout=300 interval=15 elapsed=0
+
+    probe() {
+        gcloud ai operations list --region="$REGION" --project="$PROJECT_ID" --limit=1 --quiet >/dev/null 2>&1 \
+            && gcloud run services list --region="$REGION" --project="$PROJECT_ID" --limit=1 --quiet >/dev/null 2>&1 \
+            && gcloud artifacts repositories list --location="$REGION" --project="$PROJECT_ID" --limit=1 --quiet >/dev/null 2>&1 \
+            && gcloud builds list --project="$PROJECT_ID" --limit=1 --quiet >/dev/null 2>&1 \
+            && gcloud batch jobs list --location="$REGION" --project="$PROJECT_ID" --limit=1 --quiet >/dev/null 2>&1
+    }
+
+    while ! probe; do
+        if [[ $elapsed -ge $timeout ]]; then
+            echo "Warning: APIs did not warm up within ${timeout}s — proceeding anyway."
+            return
+        fi
+        echo "  APIs not ready yet, retrying in ${interval}s... (${elapsed}s elapsed)"
+        sleep $interval
+        elapsed=$((elapsed + interval))
+    done
+    echo "  APIs ready."
+}
+
+# ==============================================================================
 # Step: build
 # ==============================================================================
 if $run_build; then
+    # Auto warm-up when following an infra step (new project protection)
+    if $run_infra; then
+        warm_up_apis
+    fi
     extract_terraform_outputs
 
     echo "Step 4: Building and Deploying Applications (Cloud Build)"


### PR DESCRIPTION
## Summary

Adds a `warm_up_apis()` helper to `deploy-all.sh` that polls Vertex AI, Cloud Run, Artifact Registry, Cloud Build, and Cloud Batch with lightweight list calls until all respond. Runs automatically when `--steps infra,build` are both requested. No-op on existing projects. Resolves #65.

## Why

On a fresh project, the agent deploy step fails with `500 INTERNAL` from Vertex AI even after Terraform enables all APIs — GCP API enablement is async and the service plane needs 1-3 min to initialize. Observed on first deploy to `gnext26-foldrun`.

## Behavior
- Polls every 15s, times out after 5 min with a non-fatal warning
- Only triggers automatically when `infra` + `build` are both in the step list
- Safe no-op on existing projects (APIs respond immediately)

## Test plan
- [ ] Verified on fresh project — no 500 on agent deploy when running `--steps infra,build`