### PR TITLE
fix(af2): disable AMBER relaxation by default until PTX fix lands

### DIFF
--- a/applications/foldrun/README.md
+++ b/applications/foldrun/README.md
@@ -16,9 +16,11 @@
 
 | Model | Source | Capabilities |
 |-------|--------|-------------|
-| [AlphaFold 2](https://github.com/google-deepmind/alphafold) | Google DeepMind | Protein monomers and multimers, AMBER relaxation |
+| [AlphaFold 2](https://github.com/google-deepmind/alphafold) | Google DeepMind | Protein monomers and multimers, AMBER relaxation (currently disabled — see note below) |
 | [OpenFold 3](https://github.com/aqlaboratory/openfold-3) | AQ Laboratory | Proteins, RNA, DNA, ligands (SMILES/CCD), covalent modifications, glycans |
 | [Boltz-2](https://github.com/jwohlwend/boltz) | MIT / jwohlwend | Proteins, RNA, DNA, ligands, covalent modifications, glycans, binding affinity |
+
+> **AF2 AMBER relaxation note:** AMBER relaxation is currently disabled by default (`run_relaxation=false`) due to a CUDA PTX version mismatch between the DeepMind AlphaFold2 container image and the Vertex AI GPU driver. Unrelaxed structures are suitable for most downstream analyses. A fix is in progress — see [PR #61](https://github.com/GoogleCloudPlatform/LifeSciences/pull/61).
 
 ## Tech Stack
 

--- a/applications/foldrun/README.md
+++ b/applications/foldrun/README.md
@@ -20,7 +20,7 @@
 | [OpenFold 3](https://github.com/aqlaboratory/openfold-3) | AQ Laboratory | Proteins, RNA, DNA, ligands (SMILES/CCD), covalent modifications, glycans |
 | [Boltz-2](https://github.com/jwohlwend/boltz) | MIT / jwohlwend | Proteins, RNA, DNA, ligands, covalent modifications, glycans, binding affinity |
 
-> **AF2 AMBER relaxation note:** AMBER relaxation is currently disabled by default (`run_relaxation=false`) due to a CUDA PTX version mismatch between the DeepMind AlphaFold2 container image and the Vertex AI GPU driver. Unrelaxed structures are suitable for most downstream analyses. A fix is in progress — see [PR #61](https://github.com/GoogleCloudPlatform/LifeSciences/pull/61).
+> **AF2 AMBER relaxation note:** AMBER relaxation is currently disabled by default (`run_relaxation=false`) due to a CUDA PTX version mismatch between the DeepMind AlphaFold2 container image and the Vertex AI GPU driver. Unrelaxed structures are suitable for most downstream analyses. A fix is in progress — see [PR #61](https://github.com/GoogleCloudPlatform/LifeSciences/pull/61). Relevant upstream context: [AlphaFold Issue #921](https://github.com/google-deepmind/alphafold/issues/921) (breaking change), [AlphaFold Commit a4315dd](https://github.com/google-deepmind/alphafold/commit/a4315dd7b8f9f543ad5f4080af4a42d431ef3b35), and [OpenMM Issue #3585](https://github.com/openmm/openmm/issues/3585).
 
 ## Tech Stack
 

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_monomer.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_monomer.py
@@ -61,7 +61,7 @@ class AF2SubmitMonomerTool(AF2Tool):
             "max_template_date", "2025-04-01"
         )  # Matches DB download date (April 2025)
         use_small_bfd = arguments.get("use_small_bfd", True)
-        run_relaxation = arguments.get("run_relaxation", True)
+        run_relaxation = arguments.get("run_relaxation", False)
         gpu_type = arguments.get(
             "gpu_type", "auto"
         )  # Default to auto-select based on sequence length
@@ -71,6 +71,21 @@ class AF2SubmitMonomerTool(AF2Tool):
         vertex_repo_path = arguments.get(
             "vertex_repo_path"
         )  # No longer needed, kept for backwards compatibility
+
+        # Warn if relaxation is explicitly requested — known to fail on A100 nodes due to
+        # a CUDA PTX version mismatch (CUDA_ERROR_UNSUPPORTED_PTX_VERSION) in the current
+        # container image. Fix is in progress (see PR #61). Relaxation is disabled by default
+        # until the fix is merged and deployed.
+        if run_relaxation:
+            return {
+                "status": "error",
+                "message": (
+                    "AMBER relaxation is temporarily disabled. The relax step currently "
+                    "fails on A100 GPU nodes with a CUDA PTX version mismatch. A fix is "
+                    "in progress. Please resubmit with run_relaxation=false to get "
+                    "unrelaxed structures, which are suitable for most downstream analyses."
+                ),
+            }
 
         # Validate: explicit mmseqs2 requires use_small_bfd=True and pre-built indexes
         if msa_method == "mmseqs2":

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_multimer.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_multimer.py
@@ -62,7 +62,7 @@ class AF2SubmitMultimerTool(AF2Tool):
             "max_template_date", "2025-04-01"
         )  # Matches DB download date (April 2025)
         use_small_bfd = arguments.get("use_small_bfd", True)
-        run_relaxation = arguments.get("run_relaxation", True)
+        run_relaxation = arguments.get("run_relaxation", False)
         gpu_type = arguments.get(
             "gpu_type", "auto"
         )  # Default to auto-select based on sequence length
@@ -73,6 +73,21 @@ class AF2SubmitMultimerTool(AF2Tool):
         vertex_repo_path = arguments.get(
             "vertex_repo_path"
         )  # No longer needed, kept for backwards compatibility
+
+        # Warn if relaxation is explicitly requested — known to fail on A100 nodes due to
+        # a CUDA PTX version mismatch (CUDA_ERROR_UNSUPPORTED_PTX_VERSION) in the current
+        # container image. Fix is in progress (see PR #61). Relaxation is disabled by default
+        # until the fix is merged and deployed.
+        if run_relaxation:
+            return {
+                "status": "error",
+                "message": (
+                    "AMBER relaxation is temporarily disabled. The relax step currently "
+                    "fails on A100 GPU nodes with a CUDA PTX version mismatch. A fix is "
+                    "in progress. Please resubmit with run_relaxation=false to get "
+                    "unrelaxed structures, which are suitable for most downstream analyses."
+                ),
+            }
 
         # Validate: explicit mmseqs2 requires use_small_bfd=True and pre-built indexes
         if msa_method == "mmseqs2":


### PR DESCRIPTION
## Summary

Defaults `run_relaxation` to `False` in AF2 monomer and multimer submission tools. If a user explicitly passes `run_relaxation=true`, the job returns an immediate error with a clear explanation rather than submitting a pipeline that will fail mid-run on the relax step.

Blocked on: #61 (CUDA PTX fix for A100 relax)

## Why

The AMBER relax step currently fails on Vertex AI A100 nodes with `CUDA_ERROR_UNSUPPORTED_PTX_VERSION (222)`. Rather than letting users submit jobs that silently fail after the predict step completes, this surfaces the issue immediately with a clear message. Unrelaxed structures are suitable for most downstream analyses.

## Behaviour change

| | Before | After |
|---|---|---|
| `run_relaxation` not specified | Runs relax (fails on A100) | Skips relax |
| `run_relaxation=false` | Skips relax | Skips relax (no change) |
| `run_relaxation=true` | Runs relax (fails on A100) | Returns error with explanation |

## Test plan
- [ ] Submit AF2 monomer without `run_relaxation` — predict completes, no relax step
- [ ] Submit AF2 monomer with `run_relaxation=true` — returns error message immediately
- [ ] Merge #61 PTX fix, revert this PR default back to `True`