### PR TITLE
feat(agent): add dedup guard to prevent double-submission of running jobs

### DIFF
--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_monomer.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_monomer.py
@@ -24,6 +24,7 @@ from google.cloud import aiplatform as vertex_ai
 
 logger = logging.getLogger(__name__)
 
+from ....utils.pipeline_dedup import check_duplicate_job
 from ..base import AF2Tool
 from ..utils.fasta_utils import (
     get_sequence_length,
@@ -62,6 +63,12 @@ class AF2SubmitMonomerTool(AF2Tool):
         )  # Matches DB download date (April 2025)
         use_small_bfd = arguments.get("use_small_bfd", True)
         run_relaxation = arguments.get("run_relaxation", False)
+
+        # Dedup: block submission if a job with the same name is already running
+        duplicate = check_duplicate_job(job_name, self.config.project, self.config.location)
+        if duplicate:
+            return duplicate
+
         gpu_type = arguments.get(
             "gpu_type", "auto"
         )  # Default to auto-select based on sequence length

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_multimer.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_multimer.py
@@ -24,6 +24,7 @@ from google.cloud import aiplatform as vertex_ai
 
 logger = logging.getLogger(__name__)
 
+from ....utils.pipeline_dedup import check_duplicate_job
 from ..base import AF2Tool
 from ..utils.fasta_utils import (
     get_sequence_length,
@@ -63,6 +64,12 @@ class AF2SubmitMultimerTool(AF2Tool):
         )  # Matches DB download date (April 2025)
         use_small_bfd = arguments.get("use_small_bfd", True)
         run_relaxation = arguments.get("run_relaxation", False)
+
+        # Dedup: block submission if a job with the same name is already running
+        duplicate = check_duplicate_job(job_name, self.config.project, self.config.location)
+        if duplicate:
+            return duplicate
+
         gpu_type = arguments.get(
             "gpu_type", "auto"
         )  # Default to auto-select based on sequence length

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/boltz2/tools/submit_prediction.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/boltz2/tools/submit_prediction.py
@@ -23,6 +23,7 @@ from typing import Any, Dict
 
 from google.cloud import aiplatform as vertex_ai
 
+from ....utils.pipeline_dedup import check_duplicate_job
 from ..base import BOLTZ2Tool
 from ..utils.input_converter import count_tokens, fasta_to_boltz2_yaml, is_boltz2_yaml, validate_boltz2_yaml
 
@@ -49,6 +50,12 @@ class BOLTZ2SubmitPredictionTool(BOLTZ2Tool):
         """
         input_data = arguments.get("input")
         job_name = arguments.get("job_name", f"boltz2_{datetime.now().strftime('%Y%m%d_%H%M%S')}")
+
+        # Dedup: block submission if a job with the same name is already running
+        duplicate = check_duplicate_job(job_name, self.config.project, self.config.location)
+        if duplicate:
+            return duplicate
+
         num_model_seeds = arguments.get("num_model_seeds", 1)
         num_diffusion_samples = arguments.get("num_diffusion_samples", 5)
         gpu_type = arguments.get("gpu_type", "auto")

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/of3/tools/submit_prediction.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/of3/tools/submit_prediction.py
@@ -23,6 +23,7 @@ from typing import Any, Dict
 
 from google.cloud import aiplatform as vertex_ai
 
+from ....utils.pipeline_dedup import check_duplicate_job
 from ..base import OF3Tool
 from ..utils.input_converter import count_tokens, fasta_to_of3_json, is_of3_json, validate_of3_json
 
@@ -53,6 +54,12 @@ class OF3SubmitPredictionTool(OF3Tool):
         """
         input_data = arguments.get("input")
         job_name = arguments.get("job_name", f"of3_{datetime.now().strftime('%Y%m%d_%H%M%S')}")
+
+        # Dedup: block submission if a job with the same name is already running
+        duplicate = check_duplicate_job(job_name, self.config.project, self.config.location)
+        if duplicate:
+            return duplicate
+
         num_model_seeds = arguments.get("num_model_seeds", 1)
         num_diffusion_samples = arguments.get("num_diffusion_samples", 5)
         gpu_type = arguments.get("gpu_type", "auto")

--- a/applications/foldrun/foldrun-agent/foldrun_app/utils/pipeline_dedup.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/utils/pipeline_dedup.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deduplication guard for pipeline job submissions.
+
+Prevents double-submitting a job with the same display name while one is
+already running. Applies across all models (AF2, OF3, Boltz-2).
+"""
+
+import logging
+from typing import Optional
+
+from google.cloud import aiplatform as vertex_ai
+from google.cloud.aiplatform_v1.types import pipeline_state
+
+logger = logging.getLogger(__name__)
+
+_RUNNING_STATES = {
+    pipeline_state.PipelineState.PIPELINE_STATE_QUEUED,
+    pipeline_state.PipelineState.PIPELINE_STATE_PENDING,
+    pipeline_state.PipelineState.PIPELINE_STATE_RUNNING,
+}
+
+
+def check_duplicate_job(
+    job_name: str,
+    project: str,
+    location: str,
+) -> Optional[dict]:
+    """Check if a pipeline job with the same display name is already running.
+
+    Args:
+        job_name: The display name to check.
+        project: GCP project ID.
+        location: GCP region.
+
+    Returns:
+        A dict with status/message if a duplicate is found, else None.
+    """
+    try:
+        existing = vertex_ai.PipelineJob.list(
+            filter=f'display_name="{job_name}"',
+            order_by="create_time desc",
+            project=project,
+            location=location,
+        )
+        for job in existing:
+            if job.state in _RUNNING_STATES:
+                job_id = job.resource_name.split("/")[-1]
+                logger.info(f"Duplicate submission blocked: '{job_name}' is already running ({job_id})")
+                return {
+                    "status": "duplicate",
+                    "message": (
+                        f"A job named '{job_name}' is already running. "
+                        f"To avoid duplicate submissions, please wait for it to complete "
+                        f"or use a different job name. "
+                        f"Existing job: {job.resource_name}"
+                    ),
+                    "job_name": job_name,
+                    "existing_job_id": job_id,
+                    "existing_job_resource": job.resource_name,
+                }
+    except Exception as e:
+        # Dedup check is best-effort — don't block submission on API errors
+        logger.warning(f"Dedup check failed for '{job_name}', proceeding: {e}")
+
+    return None


### PR DESCRIPTION
## Summary

Adds a shared `check_duplicate_job()` utility in `foldrun_app/utils/pipeline_dedup.py` that checks Vertex AI pipeline jobs by `display_name` before submitting. If a job with the same name is already in `QUEUED`, `PENDING`, or `RUNNING` state, the tool returns an informative error with the existing job resource name instead of creating a duplicate.

Applied to all 4 submit tools:
- `af2/tools/submit_monomer.py`
- `af2/tools/submit_multimer.py`
- `of3/tools/submit_prediction.py`
- `boltz2/tools/submit_prediction.py`

`submit_batch.py` is covered via delegation to monomer/multimer tools.

## Behaviour

- Auto-named jobs (timestamp suffix) are inherently unique — check is a no-op
- User-named jobs are protected against double-submit while in-flight
- Failed/completed jobs with the same name can still be resubmitted freely
- Dedup check is best-effort: API failures are logged and do not block submission

## Test plan
- [ ] Submit a named job, immediately try to submit again with the same name — second returns duplicate error with existing job resource
- [ ] Wait for job to complete, resubmit with same name — succeeds
- [ ] Auto-named jobs submit without issue