### PR TITLE
feat(viewer): job picker, docker compose, offline workaround improvements

### DIFF
--- a/applications/foldrun/src/foldrun-viewer/.env.example
+++ b/applications/foldrun/src/foldrun-viewer/.env.example
@@ -1,0 +1,3 @@
+PROJECT_ID=gnext26-foldrun
+BUCKET_NAME=gnext26-foldrun-foldrun-data
+REGION=us-central1

--- a/applications/foldrun/src/foldrun-viewer/app.py
+++ b/applications/foldrun/src/foldrun-viewer/app.py
@@ -301,7 +301,8 @@ def list_jobs():
     """
     try:
         creds, _ = google.auth.default(
-            scopes=["https://www.googleapis.com/auth/cloud-platform"]
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            quota_project_id=PROJECT_ID,
         )
         authed = google.auth.transport.requests.AuthorizedSession(creds)
 

--- a/applications/foldrun/src/foldrun-viewer/app.py
+++ b/applications/foldrun/src/foldrun-viewer/app.py
@@ -21,6 +21,8 @@ import json
 import logging
 import os
 
+import google.auth
+import google.auth.transport.requests
 from flask import Flask, abort, jsonify, render_template, request
 from google.cloud import storage
 
@@ -288,6 +290,65 @@ def get_image():
     except Exception as e:
         logger.error(f"Error fetching image from {uri}: {e}")
         return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/jobs")
+def list_jobs():
+    """List recent FoldRun pipeline jobs from Vertex AI, sorted by recency.
+
+    Works both in Cloud Run (identity token) and locally via Docker (ADC mount).
+    Returns an empty list with an error message if credentials are unavailable.
+    """
+    try:
+        creds, _ = google.auth.default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        )
+        authed = google.auth.transport.requests.AuthorizedSession(creds)
+
+        url = (
+            f"https://{REGION}-aiplatform.googleapis.com/v1"
+            f"/projects/{PROJECT_ID}/locations/{REGION}/pipelineJobs"
+        )
+        resp = authed.get(
+            url,
+            params={
+                "filter": "labels.submitted_by=foldrun-agent",
+                "orderBy": "createTime desc",
+                "pageSize": "50",
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        jobs = []
+        for pj in data.get("pipelineJobs", []):
+            labels = pj.get("labels", {})
+            resource_name = pj.get("name", "")
+            job_id = resource_name.split("/")[-1]
+            jobs.append(
+                {
+                    "job_id": job_id,
+                    "display_name": pj.get("displayName", job_id),
+                    "model_type": labels.get("model_type", "alphafold2"),
+                    "state": pj.get("state", "PIPELINE_STATE_UNSPECIFIED"),
+                    "create_time": pj.get("createTime", ""),
+                }
+            )
+
+        return jsonify({"jobs": jobs})
+
+    except google.auth.exceptions.DefaultCredentialsError:
+        logger.warning("No credentials available for /api/jobs")
+        return jsonify(
+            {
+                "jobs": [],
+                "error": "No credentials found. Ensure GOOGLE_APPLICATION_CREDENTIALS is set.",
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error listing jobs: {e}")
+        return jsonify({"jobs": [], "error": str(e)}), 500
 
 
 @app.route("/health")

--- a/applications/foldrun/src/foldrun-viewer/app.py
+++ b/applications/foldrun/src/foldrun-viewer/app.py
@@ -36,8 +36,13 @@ PROJECT_ID = os.environ["PROJECT_ID"]
 BUCKET_NAME = os.environ["BUCKET_NAME"]
 REGION = os.environ.get("REGION", "us-central1")
 
-# Initialize GCS client
-storage_client = storage.Client(project=PROJECT_ID)
+# Initialize GCS client with explicit credentials so quota project is set
+# correctly when running locally with user ADC (e.g. Docker / Cloud Shell).
+_creds, _ = google.auth.default(
+    scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    quota_project_id=PROJECT_ID,
+)
+storage_client = storage.Client(project=PROJECT_ID, credentials=_creds)
 
 
 def parse_gcs_uri(uri):

--- a/applications/foldrun/src/foldrun-viewer/compose.yml
+++ b/applications/foldrun/src/foldrun-viewer/compose.yml
@@ -9,4 +9,4 @@ services:
       REGION: ${REGION:-us-central1}
       GOOGLE_APPLICATION_CREDENTIALS: /root/.config/gcloud/application_default_credentials.json
     volumes:
-      - ~/.config/gcloud:/root/.config/gcloud:ro
+      - ${HOME}/.config/gcloud:/root/.config/gcloud:ro

--- a/applications/foldrun/src/foldrun-viewer/compose.yml
+++ b/applications/foldrun/src/foldrun-viewer/compose.yml
@@ -1,0 +1,12 @@
+services:
+  viewer:
+    image: us-central1-docker.pkg.dev/${PROJECT_ID:-gnext26-foldrun}/foldrun-repo/foldrun-viewer:latest
+    ports:
+      - "8080:8080"
+    environment:
+      PROJECT_ID: ${PROJECT_ID:-gnext26-foldrun}
+      BUCKET_NAME: ${BUCKET_NAME:-gnext26-foldrun-foldrun-data}
+      REGION: ${REGION:-us-central1}
+      GOOGLE_APPLICATION_CREDENTIALS: /root/.config/gcloud/application_default_credentials.json
+    volumes:
+      - ~/.config/gcloud:/root/.config/gcloud:ro

--- a/applications/foldrun/src/foldrun-viewer/run-local.sh
+++ b/applications/foldrun/src/foldrun-viewer/run-local.sh
@@ -7,7 +7,6 @@ PROJECT_ID=${1:-gnext26-foldrun}
 BUCKET_NAME="${2:-${PROJECT_ID}-foldrun-data}"
 REGION=${3:-us-central1}
 IMAGE="us-central1-docker.pkg.dev/${PROJECT_ID}/foldrun-repo/foldrun-viewer:latest"
-ADC_FILE="${HOME}/.config/gcloud/application_default_credentials.json"
 
 echo "Project:  $PROJECT_ID"
 echo "Bucket:   $BUCKET_NAME"
@@ -16,10 +15,30 @@ echo ""
 
 gcloud config set project "$PROJECT_ID"
 
+# Find gcloud config dir (handles Cloud Shell's non-standard paths)
+GCLOUD_CONFIG_DIR=$(gcloud info --format="value(config.paths.global_config_dir)")
+ADC_FILE="${GCLOUD_CONFIG_DIR}/application_default_credentials.json"
+
 if [ ! -f "$ADC_FILE" ]; then
   echo "Application Default Credentials not found — running login..."
   gcloud auth application-default login
+  # Re-resolve after login in case Cloud Shell wrote to a temp path
+  GCLOUD_CONFIG_DIR=$(gcloud info --format="value(config.paths.global_config_dir)")
+  ADC_FILE="${GCLOUD_CONFIG_DIR}/application_default_credentials.json"
 fi
+
+if [ ! -f "$ADC_FILE" ]; then
+  echo "ERROR: Could not find ADC credentials at $ADC_FILE"
+  echo "Try: gcloud auth application-default login"
+  exit 1
+fi
+
+echo "Credentials: $ADC_FILE"
+echo ""
+
+# Authenticate docker to Artifact Registry
+echo "Configuring Docker for Artifact Registry..."
+gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
 echo "Pulling latest viewer image..."
 docker pull "$IMAGE"
@@ -34,7 +53,7 @@ docker run --rm \
   -e PROJECT_ID="$PROJECT_ID" \
   -e BUCKET_NAME="$BUCKET_NAME" \
   -e REGION="$REGION" \
-  -e GOOGLE_APPLICATION_CREDENTIALS="/root/.config/gcloud/application_default_credentials.json" \
+  -e GOOGLE_APPLICATION_CREDENTIALS="/gcloud/application_default_credentials.json" \
   -p 8080:8080 \
-  -v "${HOME}/.config/gcloud:/root/.config/gcloud:ro" \
+  -v "${GCLOUD_CONFIG_DIR}:/gcloud:ro" \
   "$IMAGE"

--- a/applications/foldrun/src/foldrun-viewer/run-local.sh
+++ b/applications/foldrun/src/foldrun-viewer/run-local.sh
@@ -53,6 +53,8 @@ docker run --rm \
   -e PROJECT_ID="$PROJECT_ID" \
   -e BUCKET_NAME="$BUCKET_NAME" \
   -e REGION="$REGION" \
+  -e GOOGLE_CLOUD_PROJECT="$PROJECT_ID" \
+  -e GOOGLE_CLOUD_QUOTA_PROJECT="$PROJECT_ID" \
   -e GOOGLE_APPLICATION_CREDENTIALS="/gcloud/application_default_credentials.json" \
   -p 8080:8080 \
   -v "${GCLOUD_CONFIG_DIR}:/gcloud:ro" \

--- a/applications/foldrun/src/foldrun-viewer/run-local.sh
+++ b/applications/foldrun/src/foldrun-viewer/run-local.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Run the FoldRun Structure Viewer locally via Docker (Cloud Shell workaround).
+# Usage: bash run-local.sh [PROJECT_ID]
+set -e
+
+PROJECT_ID=${1:-gnext26-foldrun}
+BUCKET_NAME="${2:-${PROJECT_ID}-foldrun-data}"
+REGION=${3:-us-central1}
+IMAGE="us-central1-docker.pkg.dev/${PROJECT_ID}/foldrun-repo/foldrun-viewer:latest"
+ADC_FILE="${HOME}/.config/gcloud/application_default_credentials.json"
+
+echo "Project:  $PROJECT_ID"
+echo "Bucket:   $BUCKET_NAME"
+echo "Region:   $REGION"
+echo ""
+
+gcloud config set project "$PROJECT_ID"
+
+if [ ! -f "$ADC_FILE" ]; then
+  echo "Application Default Credentials not found — running login..."
+  gcloud auth application-default login
+fi
+
+echo "Pulling latest viewer image..."
+docker pull "$IMAGE"
+
+echo ""
+echo "Starting viewer on http://localhost:8080"
+echo "Use Cloud Shell Web Preview on port 8080 to open in browser."
+echo "Press Ctrl+C to stop."
+echo ""
+
+docker run --rm \
+  -e PROJECT_ID="$PROJECT_ID" \
+  -e BUCKET_NAME="$BUCKET_NAME" \
+  -e REGION="$REGION" \
+  -e GOOGLE_APPLICATION_CREDENTIALS="/root/.config/gcloud/application_default_credentials.json" \
+  -p 8080:8080 \
+  -v "${HOME}/.config/gcloud:/root/.config/gcloud:ro" \
+  "$IMAGE"

--- a/applications/foldrun/src/foldrun-viewer/templates/combined.html
+++ b/applications/foldrun/src/foldrun-viewer/templates/combined.html
@@ -470,7 +470,7 @@
 </head>
 <body>
     <div class="header">
-        <h1>🧬 FoldRun Structure & Analysis</h1>
+        <h1><a href="/" style="color: inherit; text-decoration: none;">🧬 FoldRun Structure & Analysis</a></h1>
         {% if job_id %}
         <p class="subtitle">Job: <a href="https://console.cloud.google.com/vertex-ai/pipelines/locations/{{ region }}/runs/{{ job_id }}?project={{ project_id }}" target="_blank" class="job-link">{{ job_id }}</a>{% if gcs_console_url %} &middot; <a href="{{ gcs_console_url }}" target="_blank" class="job-link">View files in GCS</a>{% endif %}</p>
         <div id="job-info-summary" class="job-info-summary"></div>

--- a/applications/foldrun/src/foldrun-viewer/templates/index.html
+++ b/applications/foldrun/src/foldrun-viewer/templates/index.html
@@ -16,7 +16,7 @@
             background: linear-gradient(135deg, #4285F4 0%, #1a73e8 100%);
             min-height: 100vh;
             display: flex;
-            align-items: center;
+            align-items: flex-start;
             justify-content: center;
             padding: 20px;
         }
@@ -26,8 +26,9 @@
             border-radius: 20px;
             box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
             padding: 60px;
-            max-width: 800px;
+            max-width: 900px;
             width: 100%;
+            margin: 20px auto;
         }
 
         h1 {
@@ -44,9 +45,150 @@
             font-size: 1.1rem;
         }
 
+        /* ── Job Picker ── */
+        .job-picker {
+            margin-bottom: 40px;
+        }
+
+        .job-picker h2 {
+            color: #4285F4;
+            font-size: 1.4rem;
+            margin-bottom: 16px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .refresh-btn {
+            background: none;
+            border: 1px solid #4285F4;
+            color: #4285F4;
+            border-radius: 6px;
+            padding: 2px 10px;
+            font-size: 0.8rem;
+            cursor: pointer;
+            margin-left: auto;
+        }
+
+        .refresh-btn:hover { background: #e8f0fe; }
+
+        .filter-row {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 14px;
+            flex-wrap: wrap;
+        }
+
+        .filter-row select {
+            border: 1px solid #dadce0;
+            border-radius: 6px;
+            padding: 6px 10px;
+            font-size: 0.9rem;
+            color: #333;
+            background: white;
+            cursor: pointer;
+        }
+
+        #jobs-container {
+            border: 1px solid #dadce0;
+            border-radius: 12px;
+            overflow: hidden;
+        }
+
+        .jobs-loading, .jobs-empty, .jobs-error {
+            padding: 32px;
+            text-align: center;
+            color: #666;
+            font-size: 0.95rem;
+        }
+
+        .jobs-error { color: #c5221f; }
+
+        .job-row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 14px 18px;
+            border-bottom: 1px solid #f1f3f4;
+            transition: background 0.15s;
+        }
+
+        .job-row:last-child { border-bottom: none; }
+        .job-row:hover { background: #f8f9fa; }
+
+        .model-badge {
+            font-size: 0.72rem;
+            font-weight: 600;
+            padding: 3px 8px;
+            border-radius: 20px;
+            white-space: nowrap;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+            flex-shrink: 0;
+        }
+
+        .badge-alphafold2  { background: #e8f0fe; color: #1a73e8; }
+        .badge-openfold3   { background: #e6f4ea; color: #1e8e3e; }
+        .badge-boltz2      { background: #f3e8fd; color: #7627bb; }
+
+        .state-chip {
+            font-size: 0.72rem;
+            font-weight: 600;
+            padding: 3px 8px;
+            border-radius: 20px;
+            white-space: nowrap;
+            flex-shrink: 0;
+        }
+
+        .state-succeeded  { background: #e6f4ea; color: #1e8e3e; }
+        .state-running    { background: #fff3e0; color: #e65100; }
+        .state-failed     { background: #fce8e6; color: #c5221f; }
+        .state-cancelled  { background: #f1f3f4; color: #5f6368; }
+        .state-pending    { background: #f1f3f4; color: #5f6368; }
+
+        .job-name {
+            flex: 1;
+            font-size: 0.9rem;
+            color: #202124;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .job-time {
+            font-size: 0.8rem;
+            color: #80868b;
+            white-space: nowrap;
+            flex-shrink: 0;
+        }
+
+        .view-btn {
+            background: #4285F4;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            padding: 6px 14px;
+            font-size: 0.85rem;
+            cursor: pointer;
+            text-decoration: none;
+            flex-shrink: 0;
+            display: inline-block;
+        }
+
+        .view-btn:hover { background: #1a73e8; }
+
+        .view-btn.disabled {
+            background: #dadce0;
+            color: #80868b;
+            cursor: default;
+            pointer-events: none;
+        }
+
+        /* ── Feature grid ── */
         .feature-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
             gap: 20px;
             margin: 40px 0;
         }
@@ -60,9 +202,7 @@
             transition: transform 0.3s ease;
         }
 
-        .feature-card:hover {
-            transform: translateY(-5px);
-        }
+        .feature-card:hover { transform: translateY(-5px); }
 
         .feature-card h3 {
             font-size: 1.3rem;
@@ -122,7 +262,34 @@
     <div class="container">
         <div class="logo">🧬</div>
         <h1>FoldRun Structure Viewer</h1>
-        <p class="subtitle">Protein structure prediction on Google Cloud, powered by AlphaFold2</p>
+        <p class="subtitle">Protein structure prediction on Google Cloud</p>
+
+        <!-- ── Job Picker ── -->
+        <div class="job-picker">
+            <h2>
+                Recent Jobs
+                <button class="refresh-btn" onclick="loadJobs()">↻ Refresh</button>
+            </h2>
+
+            <div class="filter-row">
+                <select id="filter-model" onchange="renderJobs()">
+                    <option value="">All models</option>
+                    <option value="alphafold2">AlphaFold2</option>
+                    <option value="openfold3">OpenFold3</option>
+                    <option value="boltz2">Boltz-2</option>
+                </select>
+                <select id="filter-state" onchange="renderJobs()">
+                    <option value="">All states</option>
+                    <option value="PIPELINE_STATE_SUCCEEDED">Succeeded</option>
+                    <option value="PIPELINE_STATE_RUNNING">Running</option>
+                    <option value="PIPELINE_STATE_FAILED">Failed</option>
+                </select>
+            </div>
+
+            <div id="jobs-container">
+                <div class="jobs-loading">Loading recent jobs…</div>
+            </div>
+        </div>
 
         <div class="feature-grid">
             <div class="feature-card">
@@ -141,18 +308,10 @@
 
         <div class="info-section">
             <h2>How to Use</h2>
-            <p>This viewer displays AlphaFold2 prediction results from Vertex AI pipelines. Access it through the FoldRun agent:</p>
+            <p>Select a completed job above, or access via the FoldRun agent:</p>
             <ul>
-                <li><code>open_structure_viewer</code> - Open viewer for a completed job</li>
-                <li><code>get_prediction_results</code> - Get results and open viewer automatically</li>
-            </ul>
-
-            <h2 style="margin-top: 25px;">Features</h2>
-            <p>The viewer provides multiple visualization modes:</p>
-            <ul>
-                <li><strong>Structure View:</strong> 3D protein structure with pLDDT coloring</li>
-                <li><strong>Analysis Dashboard:</strong> Quality metrics, plots, and job metadata</li>
-                <li><strong>Combined View:</strong> Side-by-side structure and analysis</li>
+                <li><code>open_structure_viewer</code> — Open viewer for a completed job</li>
+                <li><code>get_prediction_results</code> — Get results and open viewer automatically</li>
             </ul>
 
             <h2 style="margin-top: 25px;">pLDDT Confidence Bands</h2>
@@ -179,5 +338,112 @@
             FoldRun — Protein Structure Prediction on Google Cloud
         </p>
     </div>
+
+    <script>
+        let allJobs = [];
+        let refreshTimer = null;
+
+        const MODEL_LABELS = {
+            alphafold2: 'AlphaFold2',
+            openfold3:  'OpenFold3',
+            boltz2:     'Boltz-2',
+        };
+
+        const STATE_META = {
+            PIPELINE_STATE_SUCCEEDED:  { label: 'Succeeded', cls: 'state-succeeded' },
+            PIPELINE_STATE_RUNNING:    { label: 'Running',   cls: 'state-running'   },
+            PIPELINE_STATE_FAILED:     { label: 'Failed',    cls: 'state-failed'    },
+            PIPELINE_STATE_CANCELLING: { label: 'Cancelling',cls: 'state-cancelled' },
+            PIPELINE_STATE_CANCELLED:  { label: 'Cancelled', cls: 'state-cancelled' },
+            PIPELINE_STATE_PENDING:    { label: 'Pending',   cls: 'state-pending'   },
+            PIPELINE_STATE_QUEUED:     { label: 'Queued',    cls: 'state-pending'   },
+            PIPELINE_STATE_PAUSED:     { label: 'Paused',    cls: 'state-pending'   },
+        };
+
+        function relativeTime(isoString) {
+            if (!isoString) return '';
+            const diff = Date.now() - new Date(isoString).getTime();
+            const m = Math.floor(diff / 60000);
+            if (m < 1)  return 'just now';
+            if (m < 60) return `${m}m ago`;
+            const h = Math.floor(m / 60);
+            if (h < 24) return `${h}h ago`;
+            return `${Math.floor(h / 24)}d ago`;
+        }
+
+        function canView(state) {
+            return state === 'PIPELINE_STATE_SUCCEEDED';
+        }
+
+        function renderJobs() {
+            const modelFilter = document.getElementById('filter-model').value;
+            const stateFilter = document.getElementById('filter-state').value;
+
+            const filtered = allJobs.filter(j =>
+                (!modelFilter || j.model_type === modelFilter) &&
+                (!stateFilter || j.state === stateFilter)
+            );
+
+            const container = document.getElementById('jobs-container');
+
+            if (filtered.length === 0) {
+                container.innerHTML = '<div class="jobs-empty">No jobs found.</div>';
+                return;
+            }
+
+            container.innerHTML = filtered.map(j => {
+                const sm    = STATE_META[j.state] || { label: j.state.replace('PIPELINE_STATE_',''), cls: 'state-pending' };
+                const badge = `badge-${j.model_type}`;
+                const label = MODEL_LABELS[j.model_type] || j.model_type;
+                const viewable = canView(j.state);
+                const btnCls = viewable ? 'view-btn' : 'view-btn disabled';
+                const btnHref = viewable ? `/job/${encodeURIComponent(j.job_id)}` : '#';
+
+                return `<div class="job-row">
+                    <span class="model-badge ${badge}">${label}</span>
+                    <span class="state-chip ${sm.cls}">${sm.label}</span>
+                    <span class="job-name" title="${j.job_id}">${j.display_name || j.job_id}</span>
+                    <span class="job-time">${relativeTime(j.create_time)}</span>
+                    <a class="${btnCls}" href="${btnHref}">View</a>
+                </div>`;
+            }).join('');
+        }
+
+        async function loadJobs() {
+            document.getElementById('jobs-container').innerHTML =
+                '<div class="jobs-loading">Loading recent jobs…</div>';
+
+            clearTimeout(refreshTimer);
+
+            try {
+                const resp = await fetch('/api/jobs');
+                const data = await resp.json();
+
+                if (data.error && !data.jobs.length) {
+                    document.getElementById('jobs-container').innerHTML =
+                        `<div class="jobs-error">Could not load jobs: ${data.error}</div>`;
+                    return;
+                }
+
+                allJobs = data.jobs || [];
+                renderJobs();
+
+                // Auto-refresh while any job is running
+                const hasRunning = allJobs.some(j =>
+                    j.state === 'PIPELINE_STATE_RUNNING' ||
+                    j.state === 'PIPELINE_STATE_PENDING' ||
+                    j.state === 'PIPELINE_STATE_QUEUED'
+                );
+                if (hasRunning) {
+                    refreshTimer = setTimeout(loadJobs, 30000);
+                }
+            } catch (err) {
+                document.getElementById('jobs-container').innerHTML =
+                    `<div class="jobs-error">Failed to reach /api/jobs — is the viewer running?</div>`;
+            }
+        }
+
+        loadJobs();
+    </script>
 </body>
 </html>

--- a/applications/foldrun/terraform/viewer.tf
+++ b/applications/foldrun/terraform/viewer.tf
@@ -33,6 +33,13 @@ resource "google_storage_bucket_iam_member" "foldrun_viewer_bucket_access" {
   member = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
+# Allow the viewer to list Vertex AI pipeline jobs for the job picker
+resource "google_project_iam_member" "foldrun_viewer_aiplatform" {
+  project = var.project_id
+  role    = "roles/aiplatform.viewer"
+  member  = "serviceAccount:${google_service_account.foldrun_viewer.email}"
+}
+
 resource "google_cloud_run_v2_service" "foldrun_viewer" {
   name        = "foldrun-viewer"
   project     = var.project_id


### PR DESCRIPTION
## Summary
- Adds `/api/jobs` endpoint to list recent FoldRun pipeline jobs from Vertex AI (filtered by `labels.submitted_by=foldrun-agent`)
- Replaces static index.html with a live job browser — model badges (AF2/OF3/Boltz-2), state chips, relative timestamps, View button; auto-refreshes every 30s while jobs are running
- Logo on combined viewer links back to home page
- Adds `run-local.sh` for one-command Cloud Shell docker workaround (handles ADC login, docker auth, credential path resolution)
- Adds `compose.yml` + `.env.example` for docker compose alternative
- Fixes GCS client initialization to use `quota_project_id` for user ADC compatibility (Docker/local mode)
- Grants `roles/aiplatform.viewer` to `foldrun-viewer-sa` in Terraform so job picker works on Cloud Run

## Test plan
- [ ] Home page loads job picker and lists recent jobs
- [ ] Model badges and state chips render correctly (AF2/OF3/Boltz-2)
- [ ] View button opens combined viewer for succeeded jobs
- [ ] Combined viewer logo links back to `/`
- [ ] `run-local.sh` works end-to-end in Cloud Shell
- [ ] `/api/jobs` returns 403 gracefully if viewer SA lacks aiplatform.viewer (shows error in UI, page still loads)
- [ ] `terraform apply` provisions `roles/aiplatform.viewer` on new deployments

Closes #50