### PR TITLE
fix(viewer): only set quota_project_id for local Docker ADC, not Cloud Run SA

### DIFF
--- a/applications/foldrun/cloudbuild.yaml
+++ b/applications/foldrun/cloudbuild.yaml
@@ -315,11 +315,15 @@ steps:
         VIEWER_URL=$$(cat /workspace/viewer_url.txt)
         export AF2_VIEWER_URL=$$VIEWER_URL
 
+        ENV_VARS="GCP_PROJECT_ID=$PROJECT_ID,GCP_REGION=${_REGION},GCS_BUCKET_NAME=${_BUCKET_NAME},GCS_DATABASES_BUCKET=${_DATABASES_BUCKET},FILESTORE_ID=${_FILESTORE_ID},ALPHAFOLD_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest,OPENFOLD3_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest,BOLTZ2_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest,AF2_VIEWER_URL=$$VIEWER_URL,OF3_ANALYSIS_JOB_NAME=of3-analysis-job,BOLTZ2_ANALYSIS_JOB_NAME=boltz2-analysis-job,PIPELINES_SA_EMAIL=${_PIPELINES_SA_EMAIL}"
+        [[ -n "${_NETWORK_ID}" ]] && ENV_VARS="$$ENV_VARS,NETWORK=${_NETWORK_ID}"
+        [[ -n "${_NETWORK_PROJECT_NUMBER}" ]] && ENV_VARS="$$ENV_VARS,NETWORK_PROJECT_NUMBER=${_NETWORK_PROJECT_NUMBER}"
+
         uv run -m foldrun_app.app_utils.deploy \
           --project=$PROJECT_ID \
           --location=${_REGION} \
           --service-account=${_AGENT_SA_EMAIL} \
-          --set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_REGION=${_REGION},GCS_BUCKET_NAME=${_BUCKET_NAME},GCS_DATABASES_BUCKET=${_DATABASES_BUCKET},FILESTORE_ID=${_FILESTORE_ID},ALPHAFOLD_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/alphafold-components:latest,OPENFOLD3_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/openfold3-components:latest,BOLTZ2_COMPONENTS_IMAGE=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/boltz2-components:latest,AF2_VIEWER_URL=$$VIEWER_URL,OF3_ANALYSIS_JOB_NAME=of3-analysis-job,BOLTZ2_ANALYSIS_JOB_NAME=boltz2-analysis-job,PIPELINES_SA_EMAIL=${_PIPELINES_SA_EMAIL},NETWORK=${_NETWORK_ID},NETWORK_PROJECT_NUMBER=${_NETWORK_PROJECT_NUMBER}
+          --set-env-vars=$$ENV_VARS
     waitFor: ['deploy-viewer', 'build-push-af2-components', 'build-push-of3-components', 'build-push-boltz2-components']
 
   # ============================================================================

--- a/applications/foldrun/src/foldrun-viewer/app.py
+++ b/applications/foldrun/src/foldrun-viewer/app.py
@@ -36,11 +36,15 @@ PROJECT_ID = os.environ["PROJECT_ID"]
 BUCKET_NAME = os.environ["BUCKET_NAME"]
 REGION = os.environ.get("REGION", "us-central1")
 
-# Initialize GCS client with explicit credentials so quota project is set
-# correctly when running locally with user ADC (e.g. Docker / Cloud Shell).
+# Initialize GCS client. When running locally via Docker with user ADC
+# (GOOGLE_APPLICATION_CREDENTIALS set), we must specify quota_project_id so
+# GCS requests aren't rejected for missing billing project. On Cloud Run the
+# service account already has implicit quota project — setting it explicitly
+# causes a serviceusage.services.use permission error.
+_quota_project = PROJECT_ID if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") else None
 _creds, _ = google.auth.default(
     scopes=["https://www.googleapis.com/auth/cloud-platform"],
-    quota_project_id=PROJECT_ID,
+    quota_project_id=_quota_project,
 )
 storage_client = storage.Client(project=PROJECT_ID, credentials=_creds)
 
@@ -305,9 +309,10 @@ def list_jobs():
     Returns an empty list with an error message if credentials are unavailable.
     """
     try:
+        quota_project = PROJECT_ID if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") else None
         creds, _ = google.auth.default(
             scopes=["https://www.googleapis.com/auth/cloud-platform"],
-            quota_project_id=PROJECT_ID,
+            quota_project_id=quota_project,
         )
         authed = google.auth.transport.requests.AuthorizedSession(creds)
 


### PR DESCRIPTION
## Summary
The GCS client initialization was unconditionally setting `quota_project_id=PROJECT_ID` which broke Cloud Run: the viewer service account doesn't have `serviceusage.services.use`, causing 403 errors on all GCS and Vertex AI calls.

The quota project override is only needed when running locally via Docker with user ADC credentials (where `GOOGLE_APPLICATION_CREDENTIALS` is set). On Cloud Run the service account has an implicit quota project.

Fix: only set `quota_project_id` when `GOOGLE_APPLICATION_CREDENTIALS` env var is present.