### PR TITLE
feat(viewer): Ask FoldRun chat tab with group-based access control

### DIFF
--- a/applications/foldrun/cloudbuild.yaml
+++ b/applications/foldrun/cloudbuild.yaml
@@ -63,10 +63,12 @@ steps:
       - |
         _t=",${_BUILD_TARGET},"
         if [[ "${_BUILD_TARGET}" == "all" ]] || [[ "$$_t" == *",viewer,"* ]]; then
+          VIEWER_ENV="PROJECT_ID=$PROJECT_ID,BUCKET_NAME=${_BUCKET_NAME},REGION=${_REGION}"
+          [[ -n "${_CHAT_ACCESS_GROUP}" ]] && VIEWER_ENV="$$VIEWER_ENV,CHAT_ACCESS_GROUP=${_CHAT_ACCESS_GROUP}"
           gcloud run deploy foldrun-viewer \
             --image ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/foldrun-viewer:latest \
             --region ${_REGION} \
-            --set-env-vars PROJECT_ID=$PROJECT_ID,BUCKET_NAME=${_BUCKET_NAME},REGION=${_REGION}
+            --set-env-vars "$$VIEWER_ENV"
 
           gcloud run services describe foldrun-viewer \
             --region ${_REGION} \
@@ -397,7 +399,35 @@ steps:
         echo ""
         echo "A2A proxy deployed: $$A2A_URL"
         echo "Agent card:         $$A2A_URL/.well-known/agent.json"
+
+        # Write A2A URL for the viewer update step
+        echo -n "$$A2A_URL" > /workspace/a2a_url.txt
     waitFor: ['build-push-a2a', 'deploy-agent-engine']
+
+  # Wire A2A URL into the viewer after the A2A service is deployed
+  - id: 'update-viewer-a2a-url'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        _t=",${_BUILD_TARGET},"
+        if [[ "${_BUILD_TARGET}" != "all" ]] && [[ "$$_t" != *",viewer,"* ]] && \
+           [[ "$$_t" != *",af2,"* ]] && [[ "$$_t" != *",of3,"* ]] && \
+           [[ "$$_t" != *",boltz2,"* ]] && [[ "${_BUILD_TARGET}" != "agent" ]]; then
+          echo "Skipping viewer A2A URL update (BUILD_TARGET=${_BUILD_TARGET})"
+          exit 0
+        fi
+        A2A_URL=$$(cat /workspace/a2a_url.txt 2>/dev/null || echo "")
+        if [[ -z "$$A2A_URL" ]]; then
+          echo "No A2A URL found, skipping viewer update"
+          exit 0
+        fi
+        echo "Updating viewer with A2A_URL=$$A2A_URL"
+        gcloud run services update foldrun-viewer \
+          --region ${_REGION} \
+          --update-env-vars A2A_URL=$$A2A_URL
+    waitFor: ['deploy-a2a']
 
   # ============================================================================
   # 5. Data Download — handled locally by deploy-all.sh, not here.
@@ -407,6 +437,7 @@ substitutions:
   _REGION: us-central1
   _NETWORK_ID: ""
   _NETWORK_PROJECT_NUMBER: ""
+  _CHAT_ACCESS_GROUP: ""
   _AR_REPO: foldrun-repo
   _BUCKET_NAME: required_bucket_name
   _DATABASES_BUCKET: required_databases_bucket_name

--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -211,6 +211,7 @@ extract_terraform_outputs() {
     export SUBNET_ID="${SUBNET_ID:-}"
     export NETWORK_ID="${NETWORK_ID:-}"
     export NETWORK_PROJECT_NUMBER="${NETWORK_PROJECT_NUMBER:-}"
+    export CHAT_ACCESS_GROUP="${CHAT_ACCESS_GROUP:-}"
 
     # If terraform is available and state exists, cross-check and prefer its outputs
     # (useful immediately after --steps infra when non-default names may have been used)
@@ -311,7 +312,7 @@ if $run_build; then
     gcloud builds submit . \
         --config cloudbuild.yaml \
         --project "$PROJECT_ID" \
-        --substitutions=_REGION="$REGION",_BUCKET_NAME="$GCS_BUCKET",_FILESTORE_ID="$FILESTORE_ID",_AR_REPO="$AR_REPO",_AGENT_SA_EMAIL="$AGENT_SA_EMAIL",_PIPELINES_SA_EMAIL="$PIPELINES_SA_EMAIL",_DATABASES_BUCKET="$DATABASES_BUCKET",_NETWORK_ID="$NETWORK_ID",_NETWORK_PROJECT_NUMBER="$NETWORK_PROJECT_NUMBER",_AF2_VERSION="$AF2_VERSION",_OF3_VERSION="$OF3_VERSION",_BOLTZ_VERSION="$BOLTZ_VERSION",_BUILD_TARGET="$BUILD_TARGET" \
+        --substitutions=_REGION="$REGION",_BUCKET_NAME="$GCS_BUCKET",_FILESTORE_ID="$FILESTORE_ID",_AR_REPO="$AR_REPO",_AGENT_SA_EMAIL="$AGENT_SA_EMAIL",_PIPELINES_SA_EMAIL="$PIPELINES_SA_EMAIL",_DATABASES_BUCKET="$DATABASES_BUCKET",_NETWORK_ID="$NETWORK_ID",_NETWORK_PROJECT_NUMBER="$NETWORK_PROJECT_NUMBER",_CHAT_ACCESS_GROUP="$CHAT_ACCESS_GROUP",_AF2_VERSION="$AF2_VERSION",_OF3_VERSION="$OF3_VERSION",_BOLTZ_VERSION="$BOLTZ_VERSION",_BUILD_TARGET="$BUILD_TARGET" \
         --machine-type=e2-highcpu-8 \
         --service-account="projects/${PROJECT_ID}/serviceAccounts/${BUILD_SA_EMAIL}"
 fi

--- a/applications/foldrun/src/foldrun-viewer/app.py
+++ b/applications/foldrun/src/foldrun-viewer/app.py
@@ -17,13 +17,18 @@ FoldRun Structure Viewer
 Cloud Run web application for viewing AlphaFold2, OpenFold3, and Boltz-2 predictions
 """
 
+import base64
+import functools
 import json
 import logging
 import os
+import time
+import urllib.request
+import uuid
 
 import google.auth
 import google.auth.transport.requests
-from flask import Flask, abort, jsonify, render_template, request
+from flask import Flask, Response, abort, jsonify, render_template, request, stream_with_context
 from google.cloud import storage
 
 logging.basicConfig(level=logging.INFO)
@@ -35,6 +40,11 @@ app = Flask(__name__)
 PROJECT_ID = os.environ["PROJECT_ID"]
 BUCKET_NAME = os.environ["BUCKET_NAME"]
 REGION = os.environ.get("REGION", "us-central1")
+
+# Chat configuration (optional — chat tab is hidden when A2A_URL is unset)
+A2A_URL = os.environ.get("A2A_URL", "").rstrip("/")
+# Google Group email that controls chat access (empty = allow all IAP-authed users)
+CHAT_ACCESS_GROUP = os.environ.get("CHAT_ACCESS_GROUP", "")
 
 # Initialize GCS client. When running locally via Docker with user ADC
 # (GOOGLE_APPLICATION_CREDENTIALS set), we must specify quota_project_id so
@@ -360,6 +370,180 @@ def list_jobs():
     except Exception as e:
         logger.error(f"Error listing jobs: {e}")
         return jsonify({"jobs": [], "error": str(e)}), 500
+
+
+# ── Chat: IAP identity helpers ────────────────────────────────────────────────
+
+def _get_iap_email() -> str | None:
+    """Decode the IAP JWT assertion header to extract the user's email.
+    IAP has already verified the signature — we just decode the payload."""
+    token = request.headers.get("X-Goog-IAP-JWT-Assertion", "")
+    if not token:
+        return None
+    try:
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (4 - len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        return payload.get("email")
+    except Exception:
+        return None
+
+
+# Group membership cache: {email: (allowed, expires_monotonic)}
+_group_cache: dict[str, tuple[bool, float]] = {}
+_GROUP_CACHE_TTL = 300  # 5 minutes
+_group_resource_cache: dict[str, str] = {}  # group_email -> resource_name
+
+
+def _check_group_membership(email: str) -> bool:
+    """Return True if email is in CHAT_ACCESS_GROUP. Caches results 5 min."""
+    if not CHAT_ACCESS_GROUP:
+        return True  # no group configured → allow all IAP-authenticated users
+
+    now = time.monotonic()
+    if email in _group_cache:
+        allowed, expires = _group_cache[email]
+        if now < expires:
+            return allowed
+
+    try:
+        authed = google.auth.transport.requests.AuthorizedSession(_creds)
+
+        # Resolve group email → resource name (cached permanently per process)
+        if CHAT_ACCESS_GROUP not in _group_resource_cache:
+            resp = authed.get(
+                "https://cloudidentity.googleapis.com/v1/groups:lookup",
+                params={"groupKey.id": CHAT_ACCESS_GROUP},
+                timeout=5,
+            )
+            resp.raise_for_status()
+            _group_resource_cache[CHAT_ACCESS_GROUP] = resp.json()["name"]
+
+        group_name = _group_resource_cache[CHAT_ACCESS_GROUP]
+
+        resp = authed.get(
+            f"https://cloudidentity.googleapis.com/v1/{group_name}/memberships:checkTransitiveMembership",
+            params={"query": f"member_key_id == '{email}'"},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        allowed = resp.json().get("hasMembership", False)
+    except Exception as e:
+        logger.error(f"Group membership check failed for {email}: {e}")
+        allowed = False
+
+    _group_cache[email] = (allowed, now + _GROUP_CACHE_TTL)
+    return allowed
+
+
+def _require_chat_access(f):
+    """Decorator: 401/403 if the caller lacks chat access."""
+    @functools.wraps(f)
+    def decorated(*args, **kwargs):
+        if not CHAT_ACCESS_GROUP:
+            return f(*args, **kwargs)
+        email = _get_iap_email()
+        if not email:
+            return jsonify({"error": "Authentication required"}), 401
+        if not _check_group_membership(email):
+            return jsonify({"error": "Access restricted to demo team", "group": CHAT_ACCESS_GROUP}), 403
+        return f(*args, **kwargs)
+    return decorated
+
+
+def _get_id_token(audience: str) -> str:
+    """Fetch a Cloud Run ID token for service-to-service auth via the metadata server."""
+    url = (
+        "http://metadata.google.internal/computeMetadata/v1/instance"
+        f"/service-accounts/default/identity?audience={audience}"
+    )
+    req = urllib.request.Request(url, headers={"Metadata-Flavor": "Google"})
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return resp.read().decode()
+
+
+# ── Chat routes ───────────────────────────────────────────────────────────────
+
+@app.route("/api/chat/access")
+def chat_access():
+    """Check whether the current user has chat access and whether chat is configured."""
+    if not A2A_URL:
+        return jsonify({"enabled": False, "reason": "Chat not configured on this deployment"})
+    if not CHAT_ACCESS_GROUP:
+        return jsonify({"enabled": True, "group": None})
+    email = _get_iap_email()
+    if not email:
+        return jsonify({"enabled": False, "reason": "not_authenticated"}), 401
+    allowed = _check_group_membership(email)
+    status = 200 if allowed else 403
+    return jsonify({"enabled": allowed, "email": email, "group": CHAT_ACCESS_GROUP}), status
+
+
+@app.route("/api/chat", methods=["POST"])
+@_require_chat_access
+def chat():
+    """Proxy a chat message to foldrun-a2a and stream the response as SSE."""
+    if not A2A_URL:
+        return jsonify({"error": "Chat not configured (A2A_URL not set)"}), 503
+
+    data = request.get_json(silent=True) or {}
+    message = data.get("message", "").strip()
+    context_id = data.get("context_id") or str(uuid.uuid4())
+    job_id = data.get("job_id", "")
+
+    if not message:
+        return jsonify({"error": "message is required"}), 400
+
+    # Prefix first message with job context so the agent knows what we're looking at
+    if job_id:
+        message = f"[Viewing job: {job_id}]\n\n{message}"
+
+    def generate():
+        try:
+            token = _get_id_token(A2A_URL)
+            task_id = str(uuid.uuid4())
+            payload = {
+                "jsonrpc": "2.0",
+                "method": "tasks/send",
+                "id": task_id,
+                "params": {
+                    "id": task_id,
+                    "contextId": context_id,
+                    "message": {
+                        "role": "user",
+                        "parts": [{"type": "text", "text": message}],
+                    },
+                },
+            }
+            import requests as http_requests
+            resp = http_requests.post(
+                f"{A2A_URL}/",
+                json=payload,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=120,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+
+            text = ""
+            try:
+                for part in result["result"]["status"]["message"]["parts"]:
+                    if part.get("type") == "text":
+                        text += part["text"]
+            except (KeyError, TypeError):
+                text = json.dumps(result)
+
+            yield f"data: {json.dumps({'text': text, 'context_id': context_id, 'done': True})}\n\n"
+
+        except Exception as e:
+            logger.error(f"Chat proxy error: {e}")
+            yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
+
+    return Response(
+        stream_with_context(generate()),
+        content_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 @app.route("/health")

--- a/applications/foldrun/src/foldrun-viewer/templates/combined.html
+++ b/applications/foldrun/src/foldrun-viewer/templates/combined.html
@@ -65,9 +65,179 @@
 
         .analysis-panel {
             background: #fafafa;
-            overflow-y: auto;
-            padding: 30px;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
         }
+
+        /* ── Right-panel tab bar ── */
+        .panel-tabs {
+            display: flex;
+            border-bottom: 2px solid #4285F4;
+            background: #f8f9fa;
+            flex-shrink: 0;
+        }
+
+        .panel-tab-btn {
+            padding: 14px 22px;
+            border: none;
+            background: none;
+            font-size: 0.95rem;
+            font-weight: 600;
+            color: #80868b;
+            cursor: pointer;
+            border-bottom: 3px solid transparent;
+            margin-bottom: -2px;
+            transition: color 0.15s, border-color 0.15s;
+        }
+
+        .panel-tab-btn.active {
+            color: #4285F4;
+            border-bottom-color: #4285F4;
+        }
+
+        .panel-tab-btn:hover:not(.active) { color: #333; }
+
+        .panel-tab-btn:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+
+        .panel-tab-pane {
+            display: none;
+            flex: 1;
+            overflow-y: auto;
+        }
+
+        .panel-tab-pane.active {
+            display: flex;
+            flex-direction: column;
+        }
+
+        #analysis-pane { padding: 30px; }
+
+        /* ── Chat panel ── */
+        #chat-pane {
+            padding: 0;
+        }
+
+        .chat-messages {
+            flex: 1;
+            overflow-y: auto;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .chat-msg {
+            max-width: 85%;
+            padding: 12px 16px;
+            border-radius: 12px;
+            font-size: 0.9rem;
+            line-height: 1.6;
+        }
+
+        .chat-msg.user {
+            align-self: flex-end;
+            background: #4285F4;
+            color: white;
+            border-bottom-right-radius: 4px;
+        }
+
+        .chat-msg.agent {
+            align-self: flex-start;
+            background: white;
+            border: 1px solid #dadce0;
+            border-bottom-left-radius: 4px;
+        }
+
+        .chat-msg.agent .markdown-content h1,
+        .chat-msg.agent .markdown-content h2,
+        .chat-msg.agent .markdown-content h3 {
+            font-size: 1em;
+            margin: 8px 0 4px;
+        }
+
+        .chat-msg.agent .markdown-content p { margin: 0 0 6px; }
+        .chat-msg.agent .markdown-content p:last-child { margin-bottom: 0; }
+        .chat-msg.agent .markdown-content code {
+            background: #f1f3f4;
+            padding: 1px 5px;
+            border-radius: 3px;
+            font-size: 0.85em;
+        }
+        .chat-msg.agent .markdown-content ul,
+        .chat-msg.agent .markdown-content ol { margin: 4px 0 4px 16px; }
+
+        .chat-msg.thinking {
+            align-self: flex-start;
+            color: #80868b;
+            font-style: italic;
+            font-size: 0.85rem;
+            background: none;
+            border: none;
+            padding: 4px 0;
+        }
+
+        .chat-input-row {
+            display: flex;
+            gap: 8px;
+            padding: 14px 16px;
+            border-top: 1px solid #dadce0;
+            background: white;
+            flex-shrink: 0;
+        }
+
+        #chat-input {
+            flex: 1;
+            border: 1px solid #dadce0;
+            border-radius: 8px;
+            padding: 10px 14px;
+            font-size: 0.9rem;
+            resize: none;
+            font-family: inherit;
+            line-height: 1.4;
+            max-height: 120px;
+            outline: none;
+            transition: border-color 0.15s;
+        }
+
+        #chat-input:focus { border-color: #4285F4; }
+
+        #chat-send-btn {
+            background: #4285F4;
+            color: white;
+            border: none;
+            border-radius: 8px;
+            padding: 10px 18px;
+            font-size: 0.9rem;
+            font-weight: 600;
+            cursor: pointer;
+            align-self: flex-end;
+            transition: background 0.15s;
+            white-space: nowrap;
+        }
+
+        #chat-send-btn:hover { background: #1a73e8; }
+        #chat-send-btn:disabled { background: #dadce0; cursor: not-allowed; }
+
+        .chat-empty {
+            text-align: center;
+            padding: 40px 20px;
+            color: #80868b;
+            font-size: 0.9rem;
+        }
+
+        .chat-empty .chat-empty-icon { font-size: 2.5rem; margin-bottom: 10px; }
+
+        .chat-restricted {
+            text-align: center;
+            padding: 40px 20px;
+        }
+
+        .chat-restricted h3 { color: #c5221f; margin-bottom: 8px; }
+        .chat-restricted p { color: #80868b; font-size: 0.9rem; }
 
         .panel-header {
             background: #f8f9fa;
@@ -537,12 +707,34 @@
             </div>
         </div>
 
-        <!-- Right Panel: Analysis -->
+        <!-- Right Panel: Analysis + Chat tabs -->
         <div class="analysis-panel">
-            <div id="analysis-content">
-                <div class="loading">
-                    <div class="spinner"></div>
-                    <p>Loading analysis...</p>
+            <div class="panel-tabs">
+                <button class="panel-tab-btn active" onclick="switchRightTab('analysis')" id="tab-btn-analysis">Analysis</button>
+                <button class="panel-tab-btn" onclick="switchRightTab('chat')" id="tab-btn-chat">Ask FoldRun 🤖</button>
+            </div>
+
+            <!-- Analysis pane -->
+            <div class="panel-tab-pane active" id="analysis-pane">
+                <div id="analysis-content">
+                    <div class="loading">
+                        <div class="spinner"></div>
+                        <p>Loading analysis...</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Chat pane -->
+            <div class="panel-tab-pane" id="chat-pane">
+                <div class="chat-messages" id="chat-messages">
+                    <div class="chat-empty" id="chat-empty-state">
+                        <div class="chat-empty-icon">🤖</div>
+                        <p>Ask FoldRun about this structure,<br>prediction quality, or next steps.</p>
+                    </div>
+                </div>
+                <div class="chat-input-row">
+                    <textarea id="chat-input" rows="1" placeholder="Ask about this prediction…" onkeydown="chatKeydown(event)"></textarea>
+                    <button id="chat-send-btn" onclick="sendChat()">Send</button>
                 </div>
             </div>
         </div>
@@ -1262,6 +1454,137 @@
         window.addEventListener('DOMContentLoaded', () => {
             initViewer();
             loadAnalysis();
+            initChat();
+        });
+
+        // ── Right-panel tab switching ─────────────────────────────────────────
+        function switchRightTab(name) {
+            document.querySelectorAll('.panel-tab-btn').forEach(b => b.classList.remove('active'));
+            document.querySelectorAll('.panel-tab-pane').forEach(p => p.classList.remove('active'));
+            document.getElementById(`tab-btn-${name}`).classList.add('active');
+            document.getElementById(`${name}-pane`).classList.add('active');
+        }
+
+        // ── Chat ─────────────────────────────────────────────────────────────
+        let chatContextId = null;
+        let chatBusy = false;
+
+        async function initChat() {
+            try {
+                const resp = await fetch('/api/chat/access');
+                const data = await resp.json();
+                if (!data.enabled) {
+                    const btn = document.getElementById('tab-btn-chat');
+                    btn.disabled = true;
+                    btn.title = data.reason || 'Chat not available';
+                    document.getElementById('chat-messages').innerHTML = `
+                        <div class="chat-restricted">
+                            <h3>Chat unavailable</h3>
+                            <p>${data.reason || 'Access restricted.'}</p>
+                        </div>`;
+                }
+            } catch (e) {
+                // Non-fatal — chat access check failure just disables the tab
+                document.getElementById('tab-btn-chat').disabled = true;
+            }
+        }
+
+        function chatKeydown(e) {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                sendChat();
+            }
+        }
+
+        function appendMessage(role, html) {
+            const el = document.createElement('div');
+            el.className = `chat-msg ${role}`;
+            el.innerHTML = html;
+            const container = document.getElementById('chat-messages');
+            document.getElementById('chat-empty-state')?.remove();
+            container.appendChild(el);
+            container.scrollTop = container.scrollHeight;
+            return el;
+        }
+
+        async function sendChat() {
+            if (chatBusy) return;
+            const input = document.getElementById('chat-input');
+            const message = input.value.trim();
+            if (!message) return;
+
+            chatBusy = true;
+            input.value = '';
+            input.style.height = 'auto';
+            document.getElementById('chat-send-btn').disabled = true;
+
+            appendMessage('user', escapeHtml(message));
+            const thinking = appendMessage('thinking', '● Thinking…');
+
+            const jobId = '{{ job_id }}';
+
+            try {
+                const resp = await fetch('/api/chat', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        message,
+                        context_id: chatContextId,
+                        job_id: jobId || undefined,
+                    }),
+                });
+
+                if (!resp.ok) {
+                    const err = await resp.json().catch(() => ({}));
+                    thinking.remove();
+                    appendMessage('agent', `<em style="color:#c5221f">Error: ${err.error || resp.statusText}</em>`);
+                    return;
+                }
+
+                const reader = resp.body.getReader();
+                const decoder = new TextDecoder();
+                let buf = '';
+
+                thinking.remove();
+                const agentEl = appendMessage('agent', '<div class="markdown-content"></div>');
+                const contentEl = agentEl.querySelector('.markdown-content');
+
+                while (true) {
+                    const {done, value} = await reader.read();
+                    if (done) break;
+                    buf += decoder.decode(value, {stream: true});
+                    const lines = buf.split('\n');
+                    buf = lines.pop();
+                    for (const line of lines) {
+                        if (!line.startsWith('data: ')) continue;
+                        const data = JSON.parse(line.slice(6));
+                        if (data.context_id) chatContextId = data.context_id;
+                        if (data.text) contentEl.innerHTML = marked.parse(data.text);
+                        if (data.error) contentEl.innerHTML = `<em style="color:#c5221f">${escapeHtml(data.error)}</em>`;
+                        document.getElementById('chat-messages').scrollTop = 999999;
+                    }
+                }
+            } catch (e) {
+                thinking.remove();
+                appendMessage('agent', `<em style="color:#c5221f">Connection error: ${escapeHtml(e.message)}</em>`);
+            } finally {
+                chatBusy = false;
+                document.getElementById('chat-send-btn').disabled = false;
+                input.focus();
+            }
+        }
+
+        function escapeHtml(s) {
+            return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        }
+
+        // Auto-grow textarea
+        document.addEventListener('DOMContentLoaded', () => {
+            const ta = document.getElementById('chat-input');
+            if (ta) ta.addEventListener('input', () => {
+                ta.style.height = 'auto';
+                ta.style.height = Math.min(ta.scrollHeight, 120) + 'px';
+            });
         });
     </script>
 </body>

--- a/applications/foldrun/terraform/variables.tf
+++ b/applications/foldrun/terraform/variables.tf
@@ -112,3 +112,9 @@ variable "iap_access_domain" {
   description = "Domain to grant IAP access to the viewer (e.g., your-company.com)"
   type        = string
 }
+
+variable "chat_access_group" {
+  description = "Google Group email whose members can access the Ask FoldRun chat tab (e.g., foldrun-demo@your-company.com). Empty = all IAP-authenticated users."
+  type        = string
+  default     = ""
+}

--- a/applications/foldrun/terraform/viewer.tf
+++ b/applications/foldrun/terraform/viewer.tf
@@ -40,6 +40,32 @@ resource "google_project_iam_member" "foldrun_viewer_aiplatform" {
   member  = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
+# Allow the viewer to check Cloud Identity group membership for chat access control
+# Only provisioned when chat_access_group is configured
+resource "google_project_iam_member" "foldrun_viewer_group_viewer" {
+  count   = var.chat_access_group != "" ? 1 : 0
+  project = var.project_id
+  role    = "roles/cloudidentity.groupViewer"
+  member  = "serviceAccount:${google_service_account.foldrun_viewer.email}"
+}
+
+# Allow the viewer SA to invoke the A2A proxy for the chat endpoint
+# foldrun-a2a is deployed via Cloud Build (not terraform), so use a data source
+data "google_cloud_run_v2_service" "foldrun_a2a" {
+  name     = "foldrun-a2a"
+  project  = var.project_id
+  location = var.region
+}
+
+resource "google_cloud_run_v2_service_iam_member" "foldrun_viewer_a2a_invoker" {
+  provider = google-beta
+  project  = data.google_cloud_run_v2_service.foldrun_a2a.project
+  location = data.google_cloud_run_v2_service.foldrun_a2a.location
+  name     = data.google_cloud_run_v2_service.foldrun_a2a.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
+}
+
 resource "google_cloud_run_v2_service" "foldrun_viewer" {
   name        = "foldrun-viewer"
   project     = var.project_id


### PR DESCRIPTION
## Summary

Adds an **Ask FoldRun** tab to the combined viewer so users can chat with the FoldRun agent about the structure they're looking at, without leaving the viewer.

### What's in this PR

**`app.py`**
- `GET /api/chat/access` — checks whether chat is configured and whether the caller is in the allowed Google Group (returns 200/403/disabled state for the UI)
- `POST /api/chat` — proxies a message to `foldrun-a2a` via Cloud Run ID token auth; streams the A2A response back as SSE
- IAP JWT decoded to extract caller email; Cloud Identity Groups API checks transitive membership; results cached 5 min per email
- `@_require_chat_access` decorator applied to the chat route

**`combined.html`**
- Tab bar added to the right panel: **Analysis** (default) | **Ask FoldRun 🤖**
- Chat UI: auto-growing textarea, send on Enter, SSE streaming, `marked.js` markdown rendering, session continuity via `context_id`
- Tab is disabled (greyed out, tooltip) when chat is unavailable or user lacks group membership
- Job ID automatically prefixed on first message for agent context

**`terraform/`**
- `chat_access_group` variable (default `""` = allow all IAP-authenticated users)
- `roles/cloudidentity.groupViewer` bound to `foldrun-viewer-sa` (conditional on group being set)
- `roles/run.invoker` on `foldrun-a2a` for `foldrun-viewer-sa` (data source lookup)

**`cloudbuild.yaml`**
- `_CHAT_ACCESS_GROUP` substitution wired to viewer deploy env vars
- New `update-viewer-a2a-url` step runs after `deploy-a2a` to patch `A2A_URL` into the viewer's Cloud Run env vars

**`deploy-all.sh`**
- `CHAT_ACCESS_GROUP` env var + substitution passthrough

## Test plan
- [ ] Analysis tab still loads (no regression)
- [ ] Chat tab renders and can send/receive messages when A2A_URL is set
- [ ] Tab is disabled when `A2A_URL` is not configured
- [ ] Group restriction works: non-members get 403, tab shows access message
- [ ] `context_id` persists across messages in the same browser session
- [ ] `terraform plan` shows only expected new resources (groupViewer IAM, A2A invoker)
- [ ] `CHAT_ACCESS_GROUP=group@domain.com bash deploy-all.sh ... --build-target viewer` passes group correctly

## Deployment note

To enable the chat tab with group restriction:
```bash
CHAT_ACCESS_GROUP=foldrun-demo@your-domain.com \
  bash deploy-all.sh PROJECT_ID REGION --steps build --build-target viewer
```

Leave `CHAT_ACCESS_GROUP` unset (default) to allow all IAP-authenticated users.