### PR TITLE
feat(viewer): gate View on analysis and add Analyze button

### DIFF
--- a/applications/foldrun/src/foldrun-viewer/Dockerfile
+++ b/applications/foldrun/src/foldrun-viewer/Dockerfile
@@ -38,7 +38,7 @@ COPY app.py .
 COPY templates/ templates/
 
 # Create non-root user for security
-RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app && chmod o+w /app
 USER appuser
 
 # Set environment variables

--- a/applications/foldrun/src/foldrun-viewer/app.py
+++ b/applications/foldrun/src/foldrun-viewer/app.py
@@ -20,6 +20,8 @@ Cloud Run web application for viewing AlphaFold2, OpenFold3, and Boltz-2 predict
 import json
 import logging
 import os
+import re
+from datetime import datetime
 
 import google.auth
 import google.auth.transport.requests
@@ -158,6 +160,120 @@ def get_analysis_summary(job_id=None, summary_uri=None):
     summary_blobs.sort(key=lambda b: b.name, reverse=True)
     uri = f"gs://{BUCKET_NAME}/{summary_blobs[0].name}"
     return load_gcs_file(uri, as_json=True)
+
+
+def _get_authed_session():
+    """Return an AuthorizedSession using application default credentials."""
+    quota_project = PROJECT_ID if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") else None
+    creds, _ = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        quota_project_id=quota_project,
+    )
+    return google.auth.transport.requests.AuthorizedSession(creds)
+
+
+def _scan_analysis_state():
+    """Scan GCS for analysis state files in a single listing pass.
+
+    Returns (complete, running):
+        complete: set of 14-digit timestamps (YYYYMMDDHHMMSS) where summary.json exists
+        running:  set of timestamps where analysis_metadata.json exists but summary.json does not
+    """
+    complete = set()
+    has_metadata = set()
+    try:
+        bucket = storage_client.bucket(BUCKET_NAME)
+        blobs = bucket.list_blobs(prefix="pipeline_runs/")
+        for blob in blobs:
+            name = blob.name
+            if "/analysis/" not in name:
+                continue
+            m = re.search(r"pipeline_runs/(\d{8})_(\d{6})/", name)
+            if not m:
+                continue
+            ts = m.group(1) + m.group(2)
+            if name.endswith("/analysis/summary.json"):
+                complete.add(ts)
+            elif name.endswith("/analysis/analysis_metadata.json"):
+                has_metadata.add(ts)
+    except Exception as e:
+        logger.warning(f"Could not scan analysis state: {e}")
+    running = has_metadata - complete
+    return complete, running
+
+
+def _discover_af2_predictions(pipeline_root: str) -> list:
+    """Scan GCS for AF2 raw_prediction.pkl files under pipeline_root."""
+    bucket_name, prefix = parse_gcs_uri(pipeline_root)
+    if not prefix.endswith("/"):
+        prefix += "/"
+    bucket = storage_client.bucket(bucket_name)
+    predictions = []
+    for blob in bucket.list_blobs(prefix=prefix):
+        if blob.name.endswith("/raw_prediction.pkl"):
+            uri = f"gs://{bucket_name}/{blob.name}"
+            # Best-effort model name from parent directory
+            parent = blob.name.split("/")[-2]
+            predictions.append({"uri": uri, "model_name": parent, "ranking_confidence": 0})
+    return predictions
+
+
+def _discover_of3_predictions(pipeline_root: str) -> list:
+    """Scan GCS for OF3 *_confidences_aggregated.json files under pipeline_root."""
+    bucket_name, prefix = parse_gcs_uri(pipeline_root)
+    if not prefix.endswith("/"):
+        prefix += "/"
+    bucket = storage_client.bucket(bucket_name)
+    predictions = []
+    seen = set()
+    for blob in bucket.list_blobs(prefix=prefix):
+        name = blob.name
+        if name.endswith("_confidences_aggregated.json") and name not in seen:
+            seen.add(name)
+            base = name.replace("_confidences_aggregated.json", "")
+            sample_name = name.split("/")[-1].replace("_confidences_aggregated.json", "")
+            predictions.append(
+                {
+                    "cif_uri": f"gs://{bucket_name}/{base}_model.cif",
+                    "confidences_uri": f"gs://{bucket_name}/{base}_confidences.json",
+                    "aggregated_uri": f"gs://{bucket_name}/{name}",
+                    "sample_name": sample_name,
+                }
+            )
+    return predictions
+
+
+def _discover_boltz2_predictions(pipeline_root: str) -> list:
+    """Scan GCS for Boltz-2 confidence_*.json files under pipeline_root."""
+    bucket_name, prefix = parse_gcs_uri(pipeline_root)
+    if not prefix.endswith("/"):
+        prefix += "/"
+    bucket = storage_client.bucket(bucket_name)
+    predictions = []
+    seen = set()
+    for blob in bucket.list_blobs(prefix=prefix):
+        name = blob.name
+        if "/predictions/" not in name or not name.endswith(".json"):
+            continue
+        parts_list = name.split("/")
+        filename = parts_list[-1]
+        if "/confidence_" in name and name not in seen:
+            seen.add(name)
+            cif_filename = filename.replace("confidence_", "", 1).replace(".json", ".cif")
+            cif_name = "/".join(parts_list[:-1] + [cif_filename])
+            pde_filename = filename.replace("confidence_", "pde_", 1).replace(".json", ".npz")
+            pde_name = "/".join(parts_list[:-1] + [pde_filename])
+            sample_name = filename.replace("confidence_", "", 1).replace(".json", "")
+            predictions.append(
+                {
+                    "sample_name": sample_name,
+                    "cif_uri": f"gs://{bucket_name}/{cif_name}",
+                    "confidences_uri": "",
+                    "aggregated_uri": f"gs://{bucket_name}/{name}",
+                    "pde_uri": f"gs://{bucket_name}/{pde_name}",
+                }
+            )
+    return predictions
 
 
 @app.route("/")
@@ -307,14 +423,10 @@ def list_jobs():
 
     Works both in Cloud Run (identity token) and locally via Docker (ADC mount).
     Returns an empty list with an error message if credentials are unavailable.
+    Includes a has_analysis flag indicating whether analysis/summary.json exists.
     """
     try:
-        quota_project = PROJECT_ID if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") else None
-        creds, _ = google.auth.default(
-            scopes=["https://www.googleapis.com/auth/cloud-platform"],
-            quota_project_id=quota_project,
-        )
-        authed = google.auth.transport.requests.AuthorizedSession(creds)
+        authed = _get_authed_session()
 
         url = (
             f"https://{REGION}-aiplatform.googleapis.com/v1"
@@ -344,8 +456,19 @@ def list_jobs():
                     "model_type": labels.get("model_type", "alphafold2"),
                     "state": pj.get("state", "PIPELINE_STATE_UNSPECIFIED"),
                     "create_time": pj.get("createTime", ""),
+                    "has_analysis": False,    # populated below
+                    "analysis_running": False,
                 }
             )
+
+        # Single GCS scan to determine analysis state per job
+        complete_ts, running_ts = _scan_analysis_state()
+        for job in jobs:
+            m = re.search(r"(\d{14})$", job["job_id"])
+            if m:
+                ts = m.group(1)
+                job["has_analysis"] = ts in complete_ts
+                job["analysis_running"] = ts in running_ts
 
         return jsonify({"jobs": jobs})
 
@@ -360,6 +483,155 @@ def list_jobs():
     except Exception as e:
         logger.error(f"Error listing jobs: {e}")
         return jsonify({"jobs": [], "error": str(e)}), 500
+
+
+@app.route("/api/analyze", methods=["POST"])
+def trigger_analysis():
+    """Trigger analysis for a succeeded prediction job that has no analysis yet.
+
+    Discovers prediction outputs in GCS, writes task_config.json, and kicks off
+    the appropriate Cloud Run analysis job.
+    """
+    data = request.get_json(silent=True) or {}
+    job_id = data.get("job_id")
+    model_type = data.get("model_type", "alphafold2")
+
+    if not job_id:
+        return jsonify({"error": "job_id is required"}), 400
+
+    try:
+        authed = _get_authed_session()
+
+        # Fetch the full pipeline job to get gcsOutputDirectory
+        pj_url = (
+            f"https://{REGION}-aiplatform.googleapis.com/v1"
+            f"/projects/{PROJECT_ID}/locations/{REGION}/pipelineJobs/{job_id}"
+        )
+        pj_resp = authed.get(pj_url, timeout=15)
+        pj_resp.raise_for_status()
+        pj = pj_resp.json()
+
+        gcs_output_dir = (
+            pj.get("runtimeConfig", {}).get("gcsOutputDirectory", "").rstrip("/") + "/"
+        )
+        if not gcs_output_dir or gcs_output_dir == "/":
+            return jsonify({"error": "Could not determine gcs_output_directory for job"}), 400
+
+        analysis_path = f"{gcs_output_dir}analysis/"
+
+        # Discover predictions based on model type
+        if model_type == "openfold3":
+            raw_predictions = _discover_of3_predictions(gcs_output_dir)
+            cr_job_name = os.environ.get("OF3_ANALYSIS_JOB_NAME", "of3-analysis-job")
+        elif model_type == "boltz2":
+            raw_predictions = _discover_boltz2_predictions(gcs_output_dir)
+            cr_job_name = os.environ.get("BOLTZ2_ANALYSIS_JOB_NAME", "boltz2-analysis-job")
+        else:
+            raw_predictions = _discover_af2_predictions(gcs_output_dir)
+            cr_job_name = os.environ.get("AF2_ANALYSIS_JOB_NAME", "af2-analysis-job")
+
+        if not raw_predictions:
+            return jsonify({"error": "No prediction outputs found for this job"}), 404
+
+        # Build task_config.json in the same format the Cloud Run job expects
+        if model_type == "alphafold2":
+            predictions_cfg = [
+                {
+                    "index": i,
+                    "uri": p["uri"],
+                    "model_name": p["model_name"],
+                    "ranking_confidence": p["ranking_confidence"],
+                    "output_uri": f"{analysis_path}prediction_{i}_analysis.json",
+                }
+                for i, p in enumerate(raw_predictions)
+            ]
+        elif model_type == "openfold3":
+            predictions_cfg = [
+                {
+                    "index": i,
+                    "cif_uri": p["cif_uri"],
+                    "confidences_uri": p["confidences_uri"],
+                    "aggregated_uri": p["aggregated_uri"],
+                    "sample_name": p["sample_name"],
+                    "output_uri": f"{analysis_path}prediction_{i}_analysis.json",
+                }
+                for i, p in enumerate(raw_predictions)
+            ]
+        else:  # boltz2
+            predictions_cfg = [
+                {
+                    "index": i,
+                    "sample_name": p["sample_name"],
+                    "cif_uri": p["cif_uri"],
+                    "confidences_uri": p.get("confidences_uri", ""),
+                    "aggregated_uri": p["aggregated_uri"],
+                    "pde_uri": p.get("pde_uri", ""),
+                    "output_uri": f"{analysis_path}prediction_{i}_analysis.json",
+                }
+                for i, p in enumerate(raw_predictions)
+            ]
+
+        task_config = {
+            "job_id": job_id,
+            "analysis_path": analysis_path,
+            "task_config_uri": f"{analysis_path}task_config.json",
+            "predictions": predictions_cfg,
+        }
+
+        # Write task_config.json and analysis_metadata.json to GCS
+        tc_bucket_name, tc_blob_path = parse_gcs_uri(f"{analysis_path}task_config.json")
+        tc_bucket = storage_client.bucket(tc_bucket_name)
+
+        tc_bucket.blob(tc_blob_path).upload_from_string(
+            json.dumps(task_config, indent=2), content_type="application/json"
+        )
+        tc_bucket.blob(tc_blob_path.replace("task_config.json", "analysis_metadata.json")).upload_from_string(
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "total_predictions": len(raw_predictions),
+                    "started_at": datetime.utcnow().isoformat() + "Z",
+                    "status": "running",
+                    "model_type": model_type,
+                    "execution_method": "cloud_run_job",
+                    "triggered_by": "foldrun-viewer",
+                },
+                indent=2,
+            ),
+            content_type="application/json",
+        )
+
+        # Trigger the Cloud Run analysis job via REST API
+        cr_job_path = f"projects/{PROJECT_ID}/locations/{REGION}/jobs/{cr_job_name}"
+        cr_url = f"https://{REGION}-run.googleapis.com/v2/{cr_job_path}:run"
+        cr_body = {
+            "overrides": {
+                "taskCount": len(raw_predictions),
+                "timeout": "600s",
+                "containerOverrides": [
+                    {"env": [{"name": "ANALYSIS_PATH", "value": analysis_path}]}
+                ],
+            }
+        }
+        cr_resp = authed.post(cr_url, json=cr_body, timeout=30)
+        cr_resp.raise_for_status()
+
+        logger.info(
+            f"Triggered analysis for {job_id}: {len(raw_predictions)} tasks, job={cr_job_name}"
+        )
+        return jsonify(
+            {
+                "status": "started",
+                "job_id": job_id,
+                "model_type": model_type,
+                "total_predictions": len(raw_predictions),
+                "analysis_path": analysis_path,
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error triggering analysis for {job_id}: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
 
 
 @app.route("/health")

--- a/applications/foldrun/src/foldrun-viewer/compose.yml
+++ b/applications/foldrun/src/foldrun-viewer/compose.yml
@@ -1,5 +1,10 @@
 services:
   viewer:
+    # Default: pull published image from Artifact Registry
+    # For local dev with current source: docker compose up --build
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: us-central1-docker.pkg.dev/${PROJECT_ID:-gnext26-foldrun}/foldrun-repo/foldrun-viewer:latest
     ports:
       - "8080:8080"
@@ -7,6 +12,6 @@ services:
       PROJECT_ID: ${PROJECT_ID:-gnext26-foldrun}
       BUCKET_NAME: ${BUCKET_NAME:-gnext26-foldrun-foldrun-data}
       REGION: ${REGION:-us-central1}
-      GOOGLE_APPLICATION_CREDENTIALS: /root/.config/gcloud/application_default_credentials.json
+      GOOGLE_APPLICATION_CREDENTIALS: /gcloud/application_default_credentials.json
     volumes:
-      - ${HOME}/.config/gcloud:/root/.config/gcloud:ro
+      - ${HOME}/.config/gcloud:/gcloud:ro

--- a/applications/foldrun/src/foldrun-viewer/run-local.sh
+++ b/applications/foldrun/src/foldrun-viewer/run-local.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
-# Run the FoldRun Structure Viewer locally via Docker (Cloud Shell workaround).
-# Usage: bash run-local.sh [PROJECT_ID]
+# Run the FoldRun Structure Viewer locally via Docker.
+#
+# Usage:
+#   bash run-local.sh [PROJECT_ID]          # pull published image from Artifact Registry
+#   bash run-local.sh [PROJECT_ID] --build  # build from local source (for testing changes)
 set -e
 
 PROJECT_ID=${1:-gnext26-foldrun}
-BUCKET_NAME="${2:-${PROJECT_ID}-foldrun-data}"
-REGION=${3:-us-central1}
-IMAGE="us-central1-docker.pkg.dev/${PROJECT_ID}/foldrun-repo/foldrun-viewer:latest"
+BUCKET_NAME="${BUCKET_NAME:-${PROJECT_ID}-foldrun-data}"
+REGION="${REGION:-us-central1}"
+BUILD=false
+
+# Parse flags (--build can appear anywhere in args)
+for arg in "$@"; do
+  if [ "$arg" = "--build" ]; then BUILD=true; fi
+done
+
+LOCAL_IMAGE="foldrun-viewer:local"
+REGISTRY_IMAGE="us-central1-docker.pkg.dev/${PROJECT_ID}/foldrun-repo/foldrun-viewer:latest"
 
 echo "Project:  $PROJECT_ID"
 echo "Bucket:   $BUCKET_NAME"
 echo "Region:   $REGION"
+echo "Mode:     $([ "$BUILD" = true ] && echo 'local build' || echo 'published image')"
 echo ""
 
 gcloud config set project "$PROJECT_ID"
@@ -22,7 +34,6 @@ ADC_FILE="${GCLOUD_CONFIG_DIR}/application_default_credentials.json"
 if [ ! -f "$ADC_FILE" ]; then
   echo "Application Default Credentials not found — running login..."
   gcloud auth application-default login
-  # Re-resolve after login in case Cloud Shell wrote to a temp path
   GCLOUD_CONFIG_DIR=$(gcloud info --format="value(config.paths.global_config_dir)")
   ADC_FILE="${GCLOUD_CONFIG_DIR}/application_default_credentials.json"
 fi
@@ -36,12 +47,17 @@ fi
 echo "Credentials: $ADC_FILE"
 echo ""
 
-# Authenticate docker to Artifact Registry
-echo "Configuring Docker for Artifact Registry..."
-gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
-
-echo "Pulling latest viewer image..."
-docker pull "$IMAGE"
+if [ "$BUILD" = true ]; then
+  echo "Building image from local source..."
+  docker build -t "$LOCAL_IMAGE" "$(dirname "$0")"
+  IMAGE="$LOCAL_IMAGE"
+else
+  echo "Configuring Docker for Artifact Registry..."
+  gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+  echo "Pulling latest viewer image..."
+  docker pull "$REGISTRY_IMAGE"
+  IMAGE="$REGISTRY_IMAGE"
+fi
 
 echo ""
 echo "Starting viewer on http://localhost:8080"
@@ -50,6 +66,7 @@ echo "Press Ctrl+C to stop."
 echo ""
 
 docker run --rm \
+  --user "$(id -u):$(id -g)" \
   -e PROJECT_ID="$PROJECT_ID" \
   -e BUCKET_NAME="$BUCKET_NAME" \
   -e REGION="$REGION" \

--- a/applications/foldrun/src/foldrun-viewer/templates/index.html
+++ b/applications/foldrun/src/foldrun-viewer/templates/index.html
@@ -185,6 +185,26 @@
             pointer-events: none;
         }
 
+        .analyze-btn {
+            background: #e8f0fe;
+            color: #1a73e8;
+            border: 1px solid #1a73e8;
+            border-radius: 6px;
+            padding: 6px 14px;
+            font-size: 0.85rem;
+            cursor: pointer;
+            flex-shrink: 0;
+        }
+
+        .analyze-btn:hover { background: #d2e3fc; }
+
+        .analyze-btn:disabled {
+            background: #f1f3f4;
+            color: #80868b;
+            border-color: #dadce0;
+            cursor: default;
+        }
+
         /* ── Feature grid ── */
         .feature-grid {
             display: grid;
@@ -371,8 +391,12 @@
             return `${Math.floor(h / 24)}d ago`;
         }
 
-        function canView(state) {
-            return state === 'PIPELINE_STATE_SUCCEEDED';
+        function canView(job) {
+            return job.state === 'PIPELINE_STATE_SUCCEEDED' && job.has_analysis;
+        }
+
+        function canAnalyze(job) {
+            return job.state === 'PIPELINE_STATE_SUCCEEDED' && !job.has_analysis && !job.analysis_running;
         }
 
         function renderJobs() {
@@ -395,18 +419,57 @@
                 const sm    = STATE_META[j.state] || { label: j.state.replace('PIPELINE_STATE_',''), cls: 'state-pending' };
                 const badge = `badge-${j.model_type}`;
                 const label = MODEL_LABELS[j.model_type] || j.model_type;
-                const viewable = canView(j.state);
-                const btnCls = viewable ? 'view-btn' : 'view-btn disabled';
-                const btnHref = viewable ? `/job/${encodeURIComponent(j.job_id)}` : '#';
 
-                return `<div class="job-row">
+                let actionBtn;
+                if (canView(j)) {
+                    actionBtn = `<a class="view-btn" href="/job/${encodeURIComponent(j.job_id)}">View</a>`;
+                } else if (j.analysis_running) {
+                    actionBtn = `<a class="view-btn disabled" href="#" title="Analysis in progress">View</a>
+                                 <button class="analyze-btn" disabled title="Analysis already running">Analyzing…</button>`;
+                } else if (canAnalyze(j)) {
+                    actionBtn = `<a class="view-btn disabled" href="#" title="Run analysis first">View</a>
+                                 <button class="analyze-btn" onclick="analyzeJob('${j.job_id}','${j.model_type}',this)">Analyze</button>`;
+                } else {
+                    actionBtn = `<a class="view-btn disabled" href="#">View</a>`;
+                }
+
+                return `<div class="job-row" id="row-${j.job_id}">
                     <span class="model-badge ${badge}">${label}</span>
                     <span class="state-chip ${sm.cls}">${sm.label}</span>
                     <span class="job-name" title="${j.job_id}">${j.display_name || j.job_id}</span>
                     <span class="job-time">${relativeTime(j.create_time)}</span>
-                    <a class="${btnCls}" href="${btnHref}">View</a>
+                    ${actionBtn}
                 </div>`;
             }).join('');
+        }
+
+        async function analyzeJob(jobId, modelType, btn) {
+            btn.disabled = true;
+            btn.textContent = 'Submitting…';
+
+            try {
+                const resp = await fetch('/api/analyze', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({job_id: jobId, model_type: modelType}),
+                });
+                const data = await resp.json();
+
+                if (!resp.ok) {
+                    btn.disabled = false;
+                    btn.textContent = 'Analyze';
+                    alert(`Analysis failed: ${data.error || resp.statusText}`);
+                    return;
+                }
+
+                // Refresh the job list — server will now return analysis_running=true
+                // which will replace the Analyze button with the disabled "Analyzing…" state
+                await loadJobs();
+            } catch (err) {
+                btn.disabled = false;
+                btn.textContent = 'Analyze';
+                alert(`Error: ${err.message}`);
+            }
         }
 
         async function loadJobs() {

--- a/applications/foldrun/terraform/viewer.tf
+++ b/applications/foldrun/terraform/viewer.tf
@@ -33,11 +33,44 @@ resource "google_storage_bucket_iam_member" "foldrun_viewer_bucket_access" {
   member = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
+# Allow the viewer to write task_config.json and analysis_metadata.json to GCS
+# when triggering analysis from the UI
+resource "google_storage_bucket_iam_member" "foldrun_viewer_bucket_write" {
+  bucket = google_storage_bucket.foldrun_bucket.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.foldrun_viewer.email}"
+}
+
 # Allow the viewer to list Vertex AI pipeline jobs for the job picker
 resource "google_project_iam_member" "foldrun_viewer_aiplatform" {
   project = var.project_id
   role    = "roles/aiplatform.viewer"
   member  = "serviceAccount:${google_service_account.foldrun_viewer.email}"
+}
+
+# Allow the viewer to trigger the Cloud Run analysis jobs from the UI
+resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_af2_analysis" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_job.af2_analysis_job.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
+}
+
+resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_of3_analysis" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_job.of3_analysis_job.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
+}
+
+resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_boltz2_analysis" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_job.boltz2_analysis_job.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
 resource "google_cloud_run_v2_service" "foldrun_viewer" {


### PR DESCRIPTION
## Summary

- **Disable View for unanalyzed jobs** — the View button is now gated on `analysis/summary.json` existing in GCS; jobs that have been predicted but not analyzed show a disabled View button
- **Analyze button** — succeeded jobs without analysis get an Analyze button that discovers prediction outputs in GCS, writes `task_config.json`, and triggers the appropriate Cloud Run analysis job (`af2/of3/boltz2-analysis-job`) directly from the viewer
- **In-progress state** — if a Cloud Run analysis job is running (detected via `analysis_metadata.json` present but no `summary.json`), the button shows a disabled "Analyzing…" state on refresh so users can't double-submit
- **IAM** — `foldrun-viewer-sa` granted `storage.objectCreator` on the bucket and `run.invoker` on each analysis job in Terraform
- **Local dev improvements** — `run-local.sh` gains a `--build` flag for testing local source changes, `--user $(id -u):$(id -g)` passthrough for ADC credential access, and `compose.yml` wired up with a build context; Dockerfile gets `chmod o+w /app` to allow gunicorn control socket creation when running as non-appuser uid

## Test plan
- [ ] Confirmed locally with `bash run-local.sh <project> --build`
- [ ] Succeeded jobs with analysis show enabled View button
- [ ] Succeeded jobs without analysis show disabled View + Analyze button
- [ ] Clicking Analyze triggers analysis and button transitions to "Analyzing…" on refresh
- [ ] After analysis completes, View button becomes enabled
- [ ] `terraform plan` shows expected IAM additions only