### PR TITLE
chore(foldrun): small cleanup in check-status and cli

### DIFF
--- a/applications/foldrun/check-status.sh
+++ b/applications/foldrun/check-status.sh
@@ -29,11 +29,6 @@ echo "==========================================================================
 echo "🔍 FoldRun Ecosystem Status Checklist"
 echo "================================================================================"
 
-if [ -z "$PROJECT_ID" ]; then
-    echo "❌ Error: Project ID not found. Run 'gcloud config set project YOUR_PROJECT_ID'"
-    exit 1
-fi
-
 echo "Project: $PROJECT_ID"
 echo "Region:  $REGION"
 echo "--------------------------------------------------------------------------------"
@@ -54,33 +49,33 @@ else
 fi
 
 # 2. Check Cloud Run Viewer
-if gcloud run services describe foldrun-viewer --region=$REGION --project=$PROJECT_ID >/dev/null 2>&1; then
+if gcloud run services describe foldrun-viewer --region="$REGION" --project="$PROJECT_ID" >/dev/null 2>&1; then
     echo "✅ [Cloud Run] foldrun-viewer service is deployed and active"
 else
     echo "❌ [Cloud Run] foldrun-viewer service is missing"
 fi
 
 # 2b. Check Cloud Run A2A Proxy (optional)
-if gcloud run services describe foldrun-a2a --region=$REGION --project=$PROJECT_ID >/dev/null 2>&1; then
+if gcloud run services describe foldrun-a2a --region="$REGION" --project="$PROJECT_ID" >/dev/null 2>&1; then
     echo "✅ [Cloud Run] foldrun-a2a A2A proxy is deployed and active"
 else
     echo "⚠️  [Cloud Run] foldrun-a2a A2A proxy is not deployed (optional — deploy with src/foldrun-a2a/deploy.sh)"
 fi
 
 # 3. Check Cloud Run Analysis Jobs
-if gcloud run jobs describe af2-analysis-job --region=$REGION --project=$PROJECT_ID >/dev/null 2>&1; then
+if gcloud run jobs describe af2-analysis-job --region="$REGION" --project="$PROJECT_ID" >/dev/null 2>&1; then
     echo "✅ [Cloud Run] af2-analysis-job is deployed"
 else
     echo "❌ [Cloud Run] af2-analysis-job is missing"
 fi
 
-if gcloud run jobs describe of3-analysis-job --region=$REGION --project=$PROJECT_ID >/dev/null 2>&1; then
+if gcloud run jobs describe of3-analysis-job --region="$REGION" --project="$PROJECT_ID" >/dev/null 2>&1; then
     echo "✅ [Cloud Run] of3-analysis-job is deployed"
 else
     echo "❌ [Cloud Run] of3-analysis-job is missing"
 fi
 
-if gcloud run jobs describe boltz2-analysis-job --region=$REGION --project=$PROJECT_ID >/dev/null 2>&1; then
+if gcloud run jobs describe boltz2-analysis-job --region="$REGION" --project="$PROJECT_ID" >/dev/null 2>&1; then
     echo "✅ [Cloud Run] boltz2-analysis-job is deployed"
 else
     echo "❌ [Cloud Run] boltz2-analysis-job is missing"

--- a/applications/foldrun/foldrun-agent/foldrun_app/cli.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/cli.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""AlphaFold2 ADK Agent - AI Agent for protein structure prediction using native FunctionTools."""
+"""FoldRun ADK Agent - AI Agent for protein structure prediction (AlphaFold2 + OpenFold3) using native FunctionTools."""
 
 import asyncio
 import logging
@@ -99,15 +99,13 @@ async def run_with_retry(runner, user_id, session_id, message, max_retries=MAX_R
                     await asyncio.sleep(wait_time)
                     continue
             raise
-        except Exception:
-            raise
 
     if last_error:
         raise last_error
 
 
 async def create_pretty_agent():
-    """Create and configure the AlphaFold2 ADK agent with pretty console output."""
+    """Create and configure the FoldRun ADK agent with pretty console output."""
 
     # Display configuration banner
     project_id = os.getenv("GCP_PROJECT_ID", "Not configured")
@@ -116,7 +114,7 @@ async def create_pretty_agent():
     viewer_base_url = os.getenv("AF2_VIEWER_URL", "Not configured")
     gemini_model = os.getenv("GEMINI_MODEL", "gemini-3-flash-preview")
 
-    config_info = f"""[bold cyan]AlphaFold2 Agent Configuration[/bold cyan]
+    config_info = f"""[bold cyan]FoldRun Agent Configuration[/bold cyan]
 
 [bold]Google Cloud:[/bold]
   Project ID: [yellow]{project_id}[/yellow]
@@ -155,7 +153,7 @@ async def create_pretty_agent():
 
 
 async def run_interactive_session(agent: Agent):
-    """Run an interactive session with the AlphaFold2 agent."""
+    """Run an interactive session with the FoldRun agent."""
 
     # Create session and artifact services
     session_service = InMemorySessionService()
@@ -172,7 +170,7 @@ async def run_interactive_session(agent: Agent):
     # Welcome message
     console.print(
         Panel.fit(
-            "[bold green]AlphaFold2 ADK Agent[/bold green]\n\n"
+            "[bold green]FoldRun ADK Agent[/bold green]\n\n"
             "I can help you with:\n"
             "• Submitting protein structure predictions\n"
             "• Monitoring job progress\n"
@@ -309,12 +307,12 @@ async def run_single_query(agent: Agent, query: str):
 
 
 async def main():
-    """Main entry point for the AlphaFold2 ADK agent."""
+    """Main entry point for the FoldRun ADK agent."""
 
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="AlphaFold2 ADK Agent - AI assistant for protein structure prediction"
+        description="FoldRun ADK Agent - AI assistant for protein structure prediction (AlphaFold2 + OpenFold3)"
     )
     parser.add_argument("--query", type=str, help="Run a single query instead of interactive mode")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- `check-status.sh`: drop unreachable `PROJECT_ID` guard (the `${1:?...}` default already exits if missing) and quote `$REGION` / `$PROJECT_ID` consistently across all `gcloud` calls
- `foldrun_app/cli.py`: rename user-facing labels from "AlphaFold2 ADK Agent" → "FoldRun ADK Agent" since the agent now covers AlphaFold2 + OpenFold3
- `foldrun_app/cli.py`: remove dead `except Exception: raise` no-op in `run_with_retry`

No behavior changes — purely cleanup.

## Test plan
- [ ] `bash -n applications/foldrun/check-status.sh` passes
- [ ] `python3 -c "import ast; ast.parse(open('applications/foldrun/foldrun-agent/foldrun_app/cli.py').read())"` passes
- [ ] Run `./check-status.sh <project>` and confirm output is identical aside from the renamed banner
- [ ] Launch `foldrun_app/cli.py` and confirm the welcome panel/config banner render with the new "FoldRun" label