### PR TITLE
fix(agent): fix tool schemas, pipelines SA fallback, and FastAPI telemetry

### DIFF
--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -215,22 +215,31 @@ extract_terraform_outputs() {
     # If terraform is available and state exists, cross-check and prefer its outputs
     # (useful immediately after --steps infra when non-default names may have been used)
     if command -v terraform &>/dev/null; then
-        cd "$TERRAFORM_DIR"
-        if terraform init -reconfigure -input=false > /dev/null 2>&1; then
-            _tf() { terraform output -raw "$1" 2>/dev/null; }
-            v=$(_tf gcs_bucket_name);       [[ -n "$v" ]] && export GCS_BUCKET="$v"
-            v=$(_tf artifact_registry_repo); [[ -n "$v" ]] && export AR_REPO="$v"
-            v=$(_tf filestore_id);           [[ -n "$v" ]] && export FILESTORE_ID="$v"
-            v=$(_tf agent_sa_email);         [[ -n "$v" ]] && export AGENT_SA_EMAIL="$v"
-            v=$(_tf build_sa_email);         [[ -n "$v" ]] && export BUILD_SA_EMAIL="$v"
-            v=$(_tf pipelines_sa_email);     [[ -n "$v" ]] && export PIPELINES_SA_EMAIL="$v"
-            v=$(_tf databases_bucket_name);  [[ -n "$v" ]] && export DATABASES_BUCKET="$v"
-            v=$(_tf subnet_id);              [[ -n "$v" ]] && export SUBNET_ID="$v"
-            v=$(_tf network_id);             [[ -n "$v" ]] && export NETWORK_ID="$v"
-            v=$(_tf network_project_number); [[ -n "$v" ]] && export NETWORK_PROJECT_NUMBER="$v"
-            unset -f _tf
-        fi
-        cd ..
+        # Run terraform output cross-check in a subshell to prevent any
+        # terraform failures from propagating to the parent shell under set -e.
+        # Exports are written to a temp file and sourced back.
+        _tf_env=$(mktemp)
+        (
+            cd "$TERRAFORM_DIR" || exit 0
+            terraform init -reconfigure -input=false > /dev/null 2>&1 || exit 0
+            # terraform output exits non-zero when output is absent — always exit 0
+            _tf() { terraform output -raw "$1" 2>/dev/null || true; }
+            v=$(_tf gcs_bucket_name);        if [[ -n "$v" ]]; then echo "GCS_BUCKET=$v"; fi
+            v=$(_tf artifact_registry_repo); if [[ -n "$v" ]]; then echo "AR_REPO=$v"; fi
+            v=$(_tf filestore_id);           if [[ -n "$v" ]]; then echo "FILESTORE_ID=$v"; fi
+            v=$(_tf agent_sa_email);         if [[ -n "$v" ]]; then echo "AGENT_SA_EMAIL=$v"; fi
+            v=$(_tf build_sa_email);         if [[ -n "$v" ]]; then echo "BUILD_SA_EMAIL=$v"; fi
+            v=$(_tf pipelines_sa_email);     if [[ -n "$v" ]]; then echo "PIPELINES_SA_EMAIL=$v"; fi
+            v=$(_tf databases_bucket_name);  if [[ -n "$v" ]]; then echo "DATABASES_BUCKET=$v"; fi
+            v=$(_tf subnet_id);              if [[ -n "$v" ]]; then echo "SUBNET_ID=$v"; fi
+            v=$(_tf network_id);             if [[ -n "$v" ]]; then echo "NETWORK_ID=$v"; fi
+            v=$(_tf network_project_number); if [[ -n "$v" ]]; then echo "NETWORK_PROJECT_NUMBER=$v"; fi
+        ) > "$_tf_env" 2>/dev/null || true
+        # Source any values that terraform provided, overriding naming-convention defaults
+        while IFS='=' read -r key val; do
+            [[ -n "$key" ]] && export "$key"="$val"
+        done < "$_tf_env"
+        rm -f "$_tf_env"
     fi
 
     echo "Configuration:"

--- a/applications/foldrun/docs/actual-cost-tracking-bigquery.md
+++ b/applications/foldrun/docs/actual-cost-tracking-bigquery.md
@@ -1,0 +1,189 @@
+# FoldRun: Tracking Actual Pipeline Costs via Cloud Billing
+
+This document explains how to query the **actual billed cost** of a FoldRun prediction run using the Cloud Billing BigQuery export. The built-in `get_actual_job_costs` agent tool estimates costs from machine specs and catalog pricing — this approach gets you real post-discount, post-credit amounts directly from your billing data.
+
+## Why the Agent Estimator Isn't Enough
+
+The `get_actual_job_costs` tool computes cost from Vertex AI job metadata (machine type × runtime × catalog rate). This is accurate for list pricing but misses:
+
+- **Committed Use Discounts (CUDs)** — 1yr/3yr GPU reservations reduce effective GPU cost by 20-40%
+- **Sustained Use Discounts (SUDs)** — automatically applied when a resource runs >25% of the month
+- **Negotiated enterprise rates** — your Google Cloud contract pricing
+- **Preemption credits** — preempted FLEX_START jobs are not billed for the interrupted interval
+- **Promotional credits** — any active credit programs on the account
+
+The Cloud Billing API does not expose spend data at the resource or label level — it only provides catalog pricing and account management. The only programmatic path to label-attributed actual costs is the **Cloud Billing BigQuery export**.
+
+## How the Billing Label Works
+
+When FoldRun submits an AF2, OF3, or Boltz2 prediction via the Vertex AI Pipelines API, Vertex AI automatically stamps every GCE resource provisioned for that run with the label:
+
+```
+vertex-ai-pipelines-run-billing-id = <pipeline_billing_id>
+```
+
+This label propagates to every billable line item for that run — GPU instances, CPU instances, disks, and network egress. The `pipeline_billing_id` value can be found on the submitted job in Vertex AI and is also captured in the FoldRun job labels under the same key.
+
+FoldRun additionally applies its own labels at submission time (see `submit_monomer.py`, `submit_multimer.py`, etc.):
+
+| Label | Value | Example |
+|---|---|---|
+| `vertex-ai-pipelines-run-billing-id` | Set by Vertex AI | `abc123def456` |
+| `submitted_by` | `foldrun-agent` | `foldrun-agent` |
+| `model_type` | `alphafold2`, `openfold3`, `boltz2` | `alphafold2` |
+| `job_type` | `monomer`, `multimer` | `monomer` |
+| `seq_name` | Sequence identifier | `my-protein` |
+| `seq_len` | Residue/token count | `347` |
+| `gpu_type` | GPU tier used | `A100` |
+
+## Prerequisites
+
+### 1. Enable Cloud Billing BigQuery Export
+
+In the GCP console: **Billing → Billing export → BigQuery export → Edit settings**
+
+Enable **Detailed usage cost** export (not standard — detailed includes resource-level labels). Choose a destination project and dataset. The table will be named:
+
+```
+gcp_billing_export_resource_v1_{BILLING_ACCOUNT_ID_WITH_UNDERSCORES}
+```
+
+For example, billing account `ABCDEF-123456-FEDCBA` → table suffix `ABCDEF_123456_FEDCBA`.
+
+**Note:** export has a 1-2 day lag. Costs for jobs run today will not appear until tomorrow or the following day.
+
+### 2. Grant BigQuery Access
+
+The service account or user running the query needs `roles/bigquery.dataViewer` on the billing export dataset.
+
+### 3. Note Your Dataset Details
+
+You'll need:
+- **Project ID** where the export dataset lives (may differ from FoldRun's project)
+- **Dataset name** (e.g. `billing_export`)
+- **Billing account ID suffix** for the table name
+
+## Querying Actual Cost by Pipeline Run
+
+### Cost breakdown for a specific pipeline run
+
+```sql
+SELECT
+  label.value                                                        AS pipeline_billing_id,
+  service.description                                                AS service,
+  sku.description                                                    AS resource_sku,
+  SUM(cost)                                                          AS list_cost,
+  SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0))     AS total_credits,
+  SUM(cost)
+    + SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) AS net_cost,
+  SUM(usage.amount)                                                  AS usage_amount,
+  ANY_VALUE(usage.unit)                                              AS usage_unit,
+  MIN(usage_start_time)                                              AS started,
+  MAX(usage_end_time)                                                AS ended
+
+FROM `{project}.{dataset}.gcp_billing_export_resource_v1_{billing_account}`
+   , UNNEST(labels) AS label
+
+WHERE label.key   = 'vertex-ai-pipelines-run-billing-id'
+  AND label.value = '{pipeline_billing_id}'   -- from job labels or Vertex AI console
+  AND DATE(_PARTITIONTIME) >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+
+GROUP BY pipeline_billing_id, service, resource_sku, usage_unit
+ORDER BY net_cost DESC
+```
+
+**Replace:**
+- `{project}` — BigQuery project where export lands
+- `{dataset}` — export dataset name
+- `{billing_account}` — billing account ID with underscores (e.g. `ABCDEF_123456_FEDCBA`)
+- `{pipeline_billing_id}` — the pipeline billing ID from the job (visible in Vertex AI job labels or FoldRun job details)
+
+### All FoldRun runs in the last 30 days
+
+```sql
+SELECT
+  billing_id.value                                                       AS pipeline_billing_id,
+  ANY_VALUE(model.value)                                                 AS model_type,
+  ANY_VALUE(seq.value)                                                   AS seq_name,
+  ANY_VALUE(seqlen.value)                                                AS seq_len,
+  SUM(cost)                                                              AS list_cost,
+  SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0))         AS total_credits,
+  SUM(cost)
+    + SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0))     AS net_cost,
+  MIN(usage_start_time)                                                  AS started,
+  MAX(usage_end_time)                                                    AS ended
+
+FROM `{project}.{dataset}.gcp_billing_export_resource_v1_{billing_account}`
+   , UNNEST(labels) AS billing_id
+LEFT JOIN UNNEST(labels) AS model    ON model.key    = 'model_type'
+LEFT JOIN UNNEST(labels) AS sub      ON sub.key      = 'submitted_by'
+LEFT JOIN UNNEST(labels) AS seq      ON seq.key      = 'seq_name'
+LEFT JOIN UNNEST(labels) AS seqlen   ON seqlen.key   = 'seq_len'
+
+WHERE billing_id.key = 'vertex-ai-pipelines-run-billing-id'
+  AND sub.value      = 'foldrun-agent'
+  AND DATE(_PARTITIONTIME) >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+
+GROUP BY pipeline_billing_id
+ORDER BY started DESC
+```
+
+### Monthly spend by model type
+
+```sql
+SELECT
+  FORMAT_DATE('%Y-%m', DATE(usage_start_time))                          AS month,
+  model.value                                                           AS model_type,
+  COUNT(DISTINCT billing_id.value)                                      AS pipeline_runs,
+  SUM(cost)
+    + SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0))    AS net_cost
+
+FROM `{project}.{dataset}.gcp_billing_export_resource_v1_{billing_account}`
+   , UNNEST(labels) AS billing_id
+LEFT JOIN UNNEST(labels) AS model ON model.key  = 'model_type'
+LEFT JOIN UNNEST(labels) AS sub   ON sub.key    = 'submitted_by'
+
+WHERE billing_id.key = 'vertex-ai-pipelines-run-billing-id'
+  AND sub.value      = 'foldrun-agent'
+  AND DATE(_PARTITIONTIME) >= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+
+GROUP BY month, model_type
+ORDER BY month DESC, net_cost DESC
+```
+
+## Reading the Results
+
+| Column | What it means |
+|---|---|
+| `list_cost` | What you'd pay at catalog rates with no discounts |
+| `total_credits` | Negative number — CUDs, SUDs, promos, preemption credits |
+| `net_cost` | What you actually owe (`list_cost + total_credits`) |
+| `resource_sku` | E.g. `"A100 GPU running in Americas"`, `"N1 Custom Instance Core running in Americas"` |
+| `usage_amount` / `usage_unit` | E.g. `1.5 hours` of GPU time |
+
+## Limitations
+
+| Limitation | Detail |
+|---|---|
+| **1-2 day lag** | Billing data is not real-time. Use the agent estimator for same-day cost awareness. |
+| **Partition filter required** | Always include `DATE(_PARTITIONTIME) >= ...` to avoid full table scans (the table can be very large) |
+| **Labels on custom jobs only** | The `vertex-ai-pipelines-run-billing-id` label is on GCE resources (GPU/CPU instances). Vertex AI API calls (model serving, etc.) are billed separately without this label. For FoldRun, nearly all cost is GCE. |
+| **Pipeline orchestrator not labeled** | The Vertex AI pipeline orchestration overhead (the `caip_pipelines_*` jobs) is billed under a separate SKU and is typically a few cents per run. |
+
+## Wiring Into the Agent (Future)
+
+Once a BigQuery billing dataset is configured, `get_actual_job_costs` can be extended to query it directly:
+
+```python
+# Proposed env vars
+BILLING_EXPORT_PROJECT=gnext26-foldrun       # or separate billing project
+BILLING_EXPORT_DATASET=billing_export
+BILLING_ACCOUNT_ID=ABCDEF-123456-FEDCBA      # with dashes, normalized internally
+```
+
+The tool would:
+1. Try BigQuery first for jobs > 2 days old (accounting for export lag)
+2. Fall back to the Vertex AI job metadata estimator for recent jobs
+3. Surface a `data_source` field in results so the agent can tell the user which method was used
+
+Until then, use the queries above directly in the BigQuery console or via `bq query`.

--- a/applications/foldrun/foldrun-agent/foldrun_app/app_utils/telemetry.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/app_utils/telemetry.py
@@ -15,10 +15,16 @@
 import logging
 import os
 
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
 
 def setup_telemetry() -> str | None:
     """Configure OpenTelemetry and GenAI telemetry with GCS upload."""
     os.environ.setdefault("GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", "true")
+
+    # Instrument FastAPI globally — Agent Engine owns the app instance so we
+    # can't call instrument_app(app) directly; instrument() covers all apps.
+    FastAPIInstrumentor().instrument()
 
     bucket = os.environ.get("LOGS_BUCKET_NAME")
     capture_content = os.environ.get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "false")

--- a/applications/foldrun/foldrun-agent/foldrun_app/core/config.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/core/config.py
@@ -85,6 +85,10 @@ class CoreConfig:
         return os.getenv("GCS_DATABASES_BUCKET", os.getenv("GCS_BUCKET_NAME"))
 
     @property
+    def pipelines_sa_email(self) -> str:
+        return os.getenv("PIPELINES_SA_EMAIL", f"pipelines-sa@{self.project_id}.iam.gserviceaccount.com")
+
+    @property
     def filestore_id(self) -> str:
         return os.getenv("FILESTORE_ID")
 

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_monomer.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_monomer.py
@@ -201,7 +201,7 @@ class AF2SubmitMonomerTool(AF2Tool):
         # Submit pipeline job (DWS scheduling already baked into compiled pipeline if enabled)
         pipeline_job = vertex_ai.PipelineJob(**job_kwargs)
         pipeline_job.submit(
-            network=filestore_network, service_account=os.environ.get("PIPELINES_SA_EMAIL")
+            network=filestore_network, service_account=self.config.pipelines_sa_email
         )
 
         # Clean up

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_multimer.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/af2/tools/submit_multimer.py
@@ -204,7 +204,7 @@ class AF2SubmitMultimerTool(AF2Tool):
         # Submit pipeline job (DWS scheduling already baked into compiled pipeline if enabled)
         pipeline_job = vertex_ai.PipelineJob(**job_kwargs)
         pipeline_job.submit(
-            network=filestore_network, service_account=os.environ.get("PIPELINES_SA_EMAIL")
+            network=filestore_network, service_account=self.config.pipelines_sa_email
         )
 
         # Clean up

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/boltz2/tools/submit_prediction.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/boltz2/tools/submit_prediction.py
@@ -174,7 +174,7 @@ class BOLTZ2SubmitPredictionTool(BOLTZ2Tool):
 
         pipeline_job = vertex_ai.PipelineJob(**job_kwargs)
         pipeline_job.submit(
-            network=filestore_network, service_account=os.environ.get("PIPELINES_SA_EMAIL")
+            network=filestore_network, service_account=self.config.pipelines_sa_email
         )
 
         # Clean up temp files

--- a/applications/foldrun/foldrun-agent/foldrun_app/models/of3/tools/submit_prediction.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/models/of3/tools/submit_prediction.py
@@ -176,7 +176,7 @@ class OF3SubmitPredictionTool(OF3Tool):
 
         pipeline_job = vertex_ai.PipelineJob(**job_kwargs)
         pipeline_job.submit(
-            network=filestore_network, service_account=os.environ.get("PIPELINES_SA_EMAIL")
+            network=filestore_network, service_account=self.config.pipelines_sa_email
         )
 
         # Clean up temp files

--- a/applications/foldrun/foldrun-agent/foldrun_app/skills/job_submission/tools.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/skills/job_submission/tools.py
@@ -101,7 +101,7 @@ def submit_af2_multimer_prediction(
     )
 
 
-def submit_af2_batch_predictions(batch_config: list) -> dict:
+def submit_af2_batch_predictions(batch_config: list[dict]) -> dict:
     """Submit multiple AlphaFold2 prediction jobs in batch."""
     return get_tool("af2_submit_batch").run({"batch_config": batch_config})
 

--- a/applications/foldrun/foldrun-agent/foldrun_app/skills/storage_management/tools.py
+++ b/applications/foldrun/foldrun-agent/foldrun_app/skills/storage_management/tools.py
@@ -21,7 +21,7 @@ from foldrun_app.skills._tool_registry import get_tool
 
 def cleanup_gcs_files(
     job_id: Optional[str] = None,
-    gcs_paths: Optional[list] = None,
+    gcs_paths: Optional[list[str]] = None,
     search_only: bool = True,
     confirm_delete: bool = False,
     include_fasta: bool = False,

--- a/applications/foldrun/foldrun-agent/pyproject.toml
+++ b/applications/foldrun/foldrun-agent/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "google-cloud-run>=0.10.0",
     "google-cloud-compute>=1.19.0",
     "google-cloud-logging>=3.0.0",
+    "opentelemetry-instrumentation-fastapi>=0.59b0",
     "google-cloud-batch>=0.17.0",
     "google-cloud-artifact-registry>=1.11.0",
     "google-cloud-service-usage>=1.8.0",

--- a/applications/foldrun/foldrun-agent/tests/unit/models/of3/test_of3_compilation.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/models/of3/test_of3_compilation.py
@@ -54,8 +54,15 @@ class TestConfigModuleIsolation:
         """Loading AF2 pipeline then OF3 pipeline uses correct base images."""
         # Clear any cached config and pipeline modules
         for key in list(sys.modules.keys()):
-            if "pipeline.pipelines" in key or key == "config":
+            if key in {
+                "foldrun_app.models.af2.pipeline.config",
+                "foldrun_app.models.of3.pipeline.config",
+            } or "pipeline.pipelines" in key:
                 del sys.modules[key]
+        for pkg_name in ("foldrun_app.models.af2.pipeline", "foldrun_app.models.of3.pipeline"):
+            pkg = sys.modules.get(pkg_name)
+            if pkg and hasattr(pkg, "config"):
+                delattr(pkg, "config")
 
         # Load AF2 pipeline
         from foldrun_app.models.af2.utils.pipeline_utils import load_vertex_pipeline as load_af2
@@ -85,8 +92,15 @@ class TestConfigModuleIsolation:
     def test_of3_then_af2_config_isolation(self):
         """Loading OF3 pipeline then AF2 pipeline uses correct base images."""
         for key in list(sys.modules.keys()):
-            if "pipeline.pipelines" in key or key == "config":
+            if key in {
+                "foldrun_app.models.af2.pipeline.config",
+                "foldrun_app.models.of3.pipeline.config",
+            } or "pipeline.pipelines" in key:
                 del sys.modules[key]
+        for pkg_name in ("foldrun_app.models.af2.pipeline", "foldrun_app.models.of3.pipeline"):
+            pkg = sys.modules.get(pkg_name)
+            if pkg and hasattr(pkg, "config"):
+                delattr(pkg, "config")
 
         # Load OF3 first
         from foldrun_app.models.of3.utils.pipeline_utils import load_vertex_pipeline as load_of3

--- a/applications/foldrun/foldrun-agent/tests/unit/test_config.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/test_config.py
@@ -100,3 +100,17 @@ class TestConfig:
         assert set(d.keys()) == expected_keys
         assert d["project_id"] == _EXPECTED["GCP_PROJECT_ID"]
         assert d["bucket_name"] == _EXPECTED["GCS_BUCKET_NAME"]
+
+    def test_pipelines_sa_email_explicit(self, mock_env_vars, monkeypatch):
+        """Explicit PIPELINES_SA_EMAIL env var is used as-is."""
+        monkeypatch.setenv("PIPELINES_SA_EMAIL", "custom-sa@my-project.iam.gserviceaccount.com")
+        config = Config()
+        assert config.pipelines_sa_email == "custom-sa@my-project.iam.gserviceaccount.com"
+
+    def test_pipelines_sa_email_fallback(self, mock_env_vars, monkeypatch):
+        """pipelines_sa_email falls back to pipelines-sa@{project_id}.iam.gserviceaccount.com."""
+        monkeypatch.delenv("PIPELINES_SA_EMAIL", raising=False)
+        monkeypatch.setattr("foldrun_app.core.config.load_dotenv", lambda *a, **kw: None)
+        config = Config()
+        expected = f"pipelines-sa@{_EXPECTED['GCP_PROJECT_ID']}.iam.gserviceaccount.com"
+        assert config.pipelines_sa_email == expected

--- a/applications/foldrun/foldrun-agent/tests/unit/test_pipeline.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/test_pipeline.py
@@ -77,7 +77,7 @@ class TestPipelineRetryPolicies:
     def test_retry_on_configure_run(self):
         """ConfigureRunOp has retry policy."""
         source = self._read_pipeline_source()
-        config_idx = source.index("Configure Pipeline Run")
+        config_idx = source.index("AF2 Configure Run")
         data_idx = source.index("DataPipelineOp")
         retry_after_config = source.index("set_retry", config_idx)
         assert retry_after_config < data_idx, (

--- a/applications/foldrun/foldrun-agent/tests/unit/test_submit_service_account.py
+++ b/applications/foldrun/foldrun-agent/tests/unit/test_submit_service_account.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify all model submit tools use config.pipelines_sa_email, not raw os.environ."""
+
+import inspect
+
+
+class TestAF2SubmitServiceAccount:
+    def test_monomer_uses_config_pipelines_sa_email(self):
+        """AF2 monomer submit passes service_account via config, not raw env var."""
+        from foldrun_app.models.af2.tools.submit_monomer import AF2SubmitMonomerTool
+
+        source = inspect.getsource(AF2SubmitMonomerTool.run)
+        assert "self.config.pipelines_sa_email" in source
+        assert 'os.environ.get("PIPELINES_SA_EMAIL")' not in source
+
+    def test_multimer_uses_config_pipelines_sa_email(self):
+        """AF2 multimer submit passes service_account via config, not raw env var."""
+        from foldrun_app.models.af2.tools.submit_multimer import AF2SubmitMultimerTool
+
+        source = inspect.getsource(AF2SubmitMultimerTool.run)
+        assert "self.config.pipelines_sa_email" in source
+        assert 'os.environ.get("PIPELINES_SA_EMAIL")' not in source
+
+
+class TestOF3SubmitServiceAccount:
+    def test_uses_config_pipelines_sa_email(self):
+        """OF3 submit passes service_account via config, not raw env var."""
+        from foldrun_app.models.of3.tools.submit_prediction import OF3SubmitPredictionTool
+
+        source = inspect.getsource(OF3SubmitPredictionTool.run)
+        assert "self.config.pipelines_sa_email" in source
+        assert 'os.environ.get("PIPELINES_SA_EMAIL")' not in source
+
+
+class TestBoltz2SubmitServiceAccount:
+    def test_uses_config_pipelines_sa_email(self):
+        """Boltz2 submit passes service_account via config, not raw env var."""
+        from foldrun_app.models.boltz2.tools.submit_prediction import BOLTZ2SubmitPredictionTool
+
+        source = inspect.getsource(BOLTZ2SubmitPredictionTool.run)
+        assert "self.config.pipelines_sa_email" in source
+        assert 'os.environ.get("PIPELINES_SA_EMAIL")' not in source


### PR DESCRIPTION
## Summary

- **Tool schema fixes (17 GE failures)** — `batch_config: list` and `gcs_paths: Optional[list]` were bare unparameterized types. Gemini rejects function declarations where array fields have no `items` definition, returning `400 INVALID_ARGUMENT` and failing every request before any response could be generated. Fixed to `list[dict]` and `list[str]` respectively.

- **Pipelines SA fallback** — `submit_monomer` and `submit_multimer` called `os.environ.get("PIPELINES_SA_EMAIL")` directly with no fallback. When deploying without a `.env`, this returns `None` and the pipeline job is submitted under the default Compute SA — which `foldrun-agent-sa` cannot impersonate. Added `pipelines_sa_email` property to `CoreConfig` with a default of `pipelines-sa@{project_id}.iam.gserviceaccount.com`, matching the convention already used in `deploy-all.sh`.

- **FastAPI OTel instrumentation** — `opentelemetry-instrumentation-fastapi` was missing from dependencies and `setup_telemetry()` had no FastAPI instrumentation. Added the package and `FastAPIInstrumentor().instrument()` in `setup_telemetry()`. Global auto-instrumentation is used (rather than `instrument_app(app)`) because Agent Engine owns the FastAPI app instance and it is not accessible from user code.

## Test plan

- [ ] Deploy agent and confirm no `400 INVALID_ARGUMENT` errors in Agent Engine logs on first request
- [ ] Submit an AF2 job and confirm pipeline is submitted with `pipelines-sa@gnext26-foldrun.iam.gserviceaccount.com`
- [ ] Confirm FastAPI request spans appear in Cloud Trace after deploy
- [ ] Deploy from a clean environment (no `.env`) and verify SA fallback resolves correctly