### PR TITLE
fix(viewer): Cloud Run v2 job execution permissions and deploy-all.sh reliability

### DIFF
--- a/applications/foldrun/terraform/viewer.tf
+++ b/applications/foldrun/terraform/viewer.tf
@@ -48,6 +48,15 @@ resource "google_project_iam_member" "foldrun_viewer_aiplatform" {
   member  = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
+# Allow the viewer SA to act as the analysis SA when triggering Cloud Run jobs.
+# The Cloud Run v2 :run endpoint requires actAs on the job's service account
+# in addition to run.jobs.run on the job resource.
+resource "google_service_account_iam_member" "foldrun_viewer_actas_analysis" {
+  service_account_id = google_service_account.foldrun_analysis.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.foldrun_viewer.email}"
+}
+
 # Allow the viewer to trigger the Cloud Run analysis jobs from the UI
 resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_af2_analysis" {
   project  = var.project_id

--- a/applications/foldrun/terraform/viewer.tf
+++ b/applications/foldrun/terraform/viewer.tf
@@ -62,7 +62,7 @@ resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_af2_analysis" 
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_job.af2_analysis_job.name
-  role     = "roles/run.invoker"
+  role     = "roles/run.developer"
   member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
@@ -70,7 +70,7 @@ resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_of3_analysis" 
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_job.of3_analysis_job.name
-  role     = "roles/run.invoker"
+  role     = "roles/run.developer"
   member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
@@ -78,7 +78,7 @@ resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_boltz2_analysi
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_job.boltz2_analysis_job.name
-  role     = "roles/run.invoker"
+  role     = "roles/run.developer"
   member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 

--- a/applications/foldrun/terraform/viewer.tf
+++ b/applications/foldrun/terraform/viewer.tf
@@ -48,6 +48,17 @@ resource "google_project_iam_member" "foldrun_viewer_aiplatform" {
   member  = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
+# Minimal custom role: only run.jobs.run + run.jobs.runWithOverrides.
+# roles/run.invoker only has run.jobs.run; roles/run.developer is too broad
+# (includes delete, update, create). This custom role is the least privilege needed.
+resource "google_project_iam_custom_role" "foldrun_job_runner" {
+  role_id     = "foldrun_job_runner"
+  title       = "FoldRun Job Runner"
+  description = "Allows triggering Cloud Run Jobs with overrides from the FoldRun viewer"
+  permissions = ["run.jobs.run", "run.jobs.runWithOverrides"]
+  project     = var.project_id
+}
+
 # Allow the viewer SA to act as the analysis SA when triggering Cloud Run jobs.
 # The Cloud Run v2 :run endpoint requires actAs on the job's service account
 # in addition to run.jobs.run on the job resource.
@@ -62,7 +73,7 @@ resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_af2_analysis" 
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_job.af2_analysis_job.name
-  role     = "roles/run.developer"
+  role     = "projects/${var.project_id}/roles/foldrun_job_runner"
   member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
@@ -70,7 +81,7 @@ resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_of3_analysis" 
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_job.of3_analysis_job.name
-  role     = "roles/run.developer"
+  role     = "projects/${var.project_id}/roles/foldrun_job_runner"
   member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
@@ -78,7 +89,7 @@ resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_boltz2_analysi
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_job.boltz2_analysis_job.name
-  role     = "roles/run.developer"
+  role     = "projects/${var.project_id}/roles/foldrun_job_runner"
   member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 


### PR DESCRIPTION
## Summary

- **Viewer SA actAs on analysis SA** — Cloud Run v2 `:run` endpoint requires `iam.serviceAccountUser` on the job's service account in addition to `run.jobs.run`. Added `google_service_account_iam_member.foldrun_viewer_actas_analysis` to `viewer.tf`.

- **Minimal custom role for job execution** — `roles/run.invoker` only includes `run.jobs.run`; the viewer calls `:run` with overrides (taskCount, containerOverrides) which requires `run.jobs.runWithOverrides`. `roles/run.developer` is too broad (includes delete, update, create). Created `foldrun_job_runner` custom role with exactly the two permissions needed and replaced the three analysis job IAM bindings.

- **`deploy-all.sh` set -e reliability** — `terraform output` exits non-zero when an output key is absent, and `[[ -n "$v" ]] && export VAR=...` triggers `set -e` when v is empty. Both silently killed the script before reaching `gcloud builds submit`. Fixed by running the terraform cross-check block in a subshell and using `if/then/fi` form for conditional exports.

## Test plan

- [ ] `--steps infra` applies cleanly with no state drift
- [ ] Clicking Analyze in the viewer successfully triggers all three analysis jobs (AF2, OF3, Boltz2)
- [ ] `--steps build --build-target agent` reaches Cloud Build without dying silently
- [ ] `--steps build --build-target viewer` reaches Cloud Build without dying silently