### PR TITLE
fix(deploy): deploy-all.sh reliability — invalid identifier guard + optional .env support

### DIFF
--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -137,6 +137,25 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ==============================================================================
+# Optional .env file support
+# Load a .env file from the script directory if present. Only sets variables
+# that are not already set in the environment, so explicit env var overrides
+# and CI/CD injected values always take precedence.
+# ==============================================================================
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$_SCRIPT_DIR/.env" ]]; then
+    echo "Loading configuration from $_SCRIPT_DIR/.env"
+    while IFS='=' read -r key val; do
+        # Skip comments, empty lines, and invalid identifiers
+        [[ "$key" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "$key" ]] && continue
+        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        # Only set if not already in the environment
+        [[ -z "${!key+x}" ]] && export "$key"="$val"
+    done < "$_SCRIPT_DIR/.env"
+fi
+
+# ==============================================================================
 # Configuration
 # ==============================================================================
 PROJECT_ID=${POSITIONAL_ARGS[0]:-$(gcloud config get-value project)}

--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -235,9 +235,11 @@ extract_terraform_outputs() {
             v=$(_tf network_id);             if [[ -n "$v" ]]; then echo "NETWORK_ID=$v"; fi
             v=$(_tf network_project_number); if [[ -n "$v" ]]; then echo "NETWORK_PROJECT_NUMBER=$v"; fi
         ) > "$_tf_env" 2>/dev/null || true
-        # Source any values that terraform provided, overriding naming-convention defaults
+        # Source any values that terraform provided, overriding naming-convention defaults.
+        # Only export keys that are valid shell identifiers (letters/digits/underscores,
+        # not starting with a digit) to guard against terraform warning lines leaking in.
         while IFS='=' read -r key val; do
-            [[ -n "$key" ]] && export "$key"="$val"
+            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] && export "$key"="$val"
         done < "$_tf_env"
         rm -f "$_tf_env"
     fi


### PR DESCRIPTION
## Summary

- **Invalid identifier guard** — `terraform output` warning lines (e.g. `│ Warning: No outputs found`) were leaking into the temp env file and causing `export: not a valid identifier` errors under `set -e`, killing the script silently before reaching `gcloud builds submit`. Added a regex guard `^[A-Za-z_][A-Za-z0-9_]*$` to skip any non-identifier lines.

- **Optional `.env` file support** — Users with non-default resource naming (custom bucket names, Shared VPC, etc.) can now drop a `.env` file alongside `deploy-all.sh` instead of prefixing every invocation with env vars. The file is loaded only if present (silent skip otherwise). Priority order is preserved:
  1. Env vars set before invoking the script (highest)
  2. `.env` file values
  3. Terraform outputs
  4. FoldRun naming-convention defaults

## Test plan

- [ ] Run `./deploy-all.sh <project> <region> --steps build --build-target agent` in an environment where terraform outputs warnings — confirm no identifier errors
- [ ] Create a `.env` with custom values, confirm they are picked up
- [ ] Set an env var explicitly before the call, confirm it takes precedence over `.env`
- [ ] Run without a `.env` file, confirm script proceeds normally