### PR TITLE
fix(deploy): robust terraform output parsing — identifier guard, box-char filter, optional .env

### DIFF
--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -137,6 +137,25 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ==============================================================================
+# Optional .env file support
+# Load a .env file from the script directory if present. Only sets variables
+# that are not already set in the environment, so explicit env var overrides
+# and CI/CD injected values always take precedence.
+# ==============================================================================
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$_SCRIPT_DIR/.env" ]]; then
+    echo "Loading configuration from $_SCRIPT_DIR/.env"
+    while IFS='=' read -r key val; do
+        # Skip comments, empty lines, and invalid identifiers
+        [[ "$key" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "$key" ]] && continue
+        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        # Only set if not already in the environment
+        [[ -z "${!key+x}" ]] && export "$key"="$val"
+    done < "$_SCRIPT_DIR/.env"
+fi
+
+# ==============================================================================
 # Configuration
 # ==============================================================================
 PROJECT_ID=${POSITIONAL_ARGS[0]:-$(gcloud config get-value project)}

--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -241,8 +241,14 @@ extract_terraform_outputs() {
         (
             cd "$TERRAFORM_DIR" || exit 0
             terraform init -reconfigure -input=false > /dev/null 2>&1 || exit 0
-            # terraform output exits non-zero when output is absent — always exit 0
-            _tf() { terraform output -raw "$1" 2>/dev/null || true; }
+            # terraform output exits non-zero when output is absent — always exit 0.
+            # In C locale, [:print:] covers only ASCII 0x20-0x7e, so box-drawing chars
+            # (UTF-8 multi-byte, e.g. ╷ │ ╵) and ANSI escape sequences (\x1b) are
+            # filtered out before the value reaches the env file.
+            _tf() { terraform output -raw "$1" 2>/dev/null \
+                | LC_ALL=C grep -v '^[^[:print:]]' \
+                | head -1 \
+                || true; }
             v=$(_tf gcs_bucket_name);        if [[ -n "$v" ]]; then echo "GCS_BUCKET=$v"; fi
             v=$(_tf artifact_registry_repo); if [[ -n "$v" ]]; then echo "AR_REPO=$v"; fi
             v=$(_tf filestore_id);           if [[ -n "$v" ]]; then echo "FILESTORE_ID=$v"; fi

--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -235,9 +235,11 @@ extract_terraform_outputs() {
             v=$(_tf network_id);             if [[ -n "$v" ]]; then echo "NETWORK_ID=$v"; fi
             v=$(_tf network_project_number); if [[ -n "$v" ]]; then echo "NETWORK_PROJECT_NUMBER=$v"; fi
         ) > "$_tf_env" 2>/dev/null || true
-        # Source any values that terraform provided, overriding naming-convention defaults
+        # Source any values that terraform provided, overriding naming-convention defaults.
+        # Only export keys that are valid shell identifiers (letters/digits/underscores,
+        # not starting with a digit) to guard against terraform warning lines leaking in.
         while IFS='=' read -r key val; do
-            [[ -n "$key" ]] && export "$key"="$val"
+            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] && export "$key"="$val"
         done < "$_tf_env"
         rm -f "$_tf_env"
     fi


### PR DESCRIPTION
## Summary

Three fixes to `deploy-all.sh` terraform output parsing, all triggered by real deployment failures.

### 1. Invalid identifier guard
`terraform output` warning lines (e.g. `│ Warning: No outputs found`) were leaking into the temp env file and causing `export: not a valid identifier` errors under `set -e`, silently killing the script before reaching `gcloud builds submit`.

**Fix:** Regex guard `^[A-Za-z_][A-Za-z0-9_]*$` on keys before export.

### 2. Box-drawing character filter (reported by colleague on `foldrun-billing-demo-v1`)
`terraform output -raw` prints warning boxes (`╷ │ ╵`) to **stdout** (not stderr) when an output is absent. The key regex validated `GCS_BUCKET` as a valid identifier, but the value `╷` passed through, resulting in `GCS_BUCKET=╷` being exported and `gcloud builds submit` failing with:
```
could not parse service account URL: service account "\x1b[33m╷\x1b[0m" does not match regex
```

**Fix:** Pipe `_tf()` output through `LC_ALL=C grep -v '^[^[:print:]']'` — in C locale `[:print:]` is ASCII-only, so multi-byte box chars and ANSI escapes are stripped at source.

### 3. Optional `.env` file support
Users with non-default resource naming can drop a `.env` alongside `deploy-all.sh` instead of prefixing every invocation. Priority order preserved: explicit env vars > `.env` > terraform outputs > naming convention defaults.

## Test plan
- [ ] Run `--steps build` with terraform installed but no state (no outputs) — confirm `Configuration:` shows correct naming-convention defaults, not `╷`
- [ ] Run `--steps build` without terraform installed — confirm silent skip, correct defaults
- [ ] Create a `.env` with custom values — confirm they are picked up
- [ ] Set an env var before the call — confirm it takes precedence over `.env`