### PR TITLE
feat(viewer): quality badge on job index with pagination and slower refresh

### DIFF
--- a/applications/foldrun/src/foldrun-viewer/app.py
+++ b/applications/foldrun/src/foldrun-viewer/app.py
@@ -498,7 +498,8 @@ def job_quality(job_id):
     """
     try:
         summary = get_analysis_summary(job_id=job_id)
-        qm = summary.get("quality_metrics", {})
+        # quality_metrics is nested under summary["summary"], not at the root
+        qm = summary.get("summary", {}).get("quality_metrics", {})
         return jsonify({
             "quality_assessment": qm.get("quality_assessment", ""),
             "best_model_plddt": qm.get("best_model_plddt"),

--- a/applications/foldrun/src/foldrun-viewer/app.py
+++ b/applications/foldrun/src/foldrun-viewer/app.py
@@ -421,26 +421,26 @@ def get_image():
 def list_jobs():
     """List recent FoldRun pipeline jobs from Agent Platform, sorted by recency.
 
-    Works both in Cloud Run (identity token) and locally via Docker (ADC mount).
-    Returns an empty list with an error message if credentials are unavailable.
-    Includes a has_analysis flag indicating whether analysis/summary.json exists.
+    Supports pagination via ?page_token=<token>. Returns 20 jobs per page plus
+    a next_page_token if more results exist.
     """
     try:
         authed = _get_authed_session()
+        page_token = request.args.get("page_token", "")
 
         url = (
             f"https://{REGION}-aiplatform.googleapis.com/v1"
             f"/projects/{PROJECT_ID}/locations/{REGION}/pipelineJobs"
         )
-        resp = authed.get(
-            url,
-            params={
-                "filter": "labels.submitted_by=foldrun-agent",
-                "orderBy": "createTime desc",
-                "pageSize": "50",
-            },
-            timeout=10,
-        )
+        params = {
+            "filter": "labels.submitted_by=foldrun-agent",
+            "orderBy": "createTime desc",
+            "pageSize": "20",
+        }
+        if page_token:
+            params["pageToken"] = page_token
+
+        resp = authed.get(url, params=params, timeout=10)
         resp.raise_for_status()
         data = resp.json()
 
@@ -456,7 +456,7 @@ def list_jobs():
                     "model_type": labels.get("model_type", "alphafold2"),
                     "state": pj.get("state", "PIPELINE_STATE_UNSPECIFIED"),
                     "create_time": pj.get("createTime", ""),
-                    "has_analysis": False,    # populated below
+                    "has_analysis": False,
                     "analysis_running": False,
                 }
             )
@@ -470,7 +470,10 @@ def list_jobs():
                 job["has_analysis"] = ts in complete_ts
                 job["analysis_running"] = ts in running_ts
 
-        return jsonify({"jobs": jobs})
+        return jsonify({
+            "jobs": jobs,
+            "next_page_token": data.get("nextPageToken", ""),
+        })
 
     except google.auth.exceptions.DefaultCredentialsError:
         logger.warning("No credentials available for /api/jobs")
@@ -483,6 +486,26 @@ def list_jobs():
     except Exception as e:
         logger.error(f"Error listing jobs: {e}")
         return jsonify({"jobs": [], "error": str(e)}), 500
+
+
+@app.route("/api/quality/<job_id>")
+def job_quality(job_id):
+    """Return quality assessment for a single analyzed job (lazy-loaded by the UI).
+
+    Reads quality_metrics from the job's analysis/summary.json. Returns 404 if
+    no summary exists yet. Called per-row after the job list renders so it never
+    blocks the initial page load.
+    """
+    try:
+        summary = get_analysis_summary(job_id=job_id)
+        qm = summary.get("quality_metrics", {})
+        return jsonify({
+            "quality_assessment": qm.get("quality_assessment", ""),
+            "best_model_plddt": qm.get("best_model_plddt"),
+            "best_model_pae": qm.get("best_model_pae"),
+        })
+    except Exception:
+        return jsonify({"quality_assessment": ""}), 404
 
 
 @app.route("/api/analyze", methods=["POST"])

--- a/applications/foldrun/src/foldrun-viewer/run-local.sh
+++ b/applications/foldrun/src/foldrun-viewer/run-local.sh
@@ -48,8 +48,8 @@ echo "Credentials: $ADC_FILE"
 echo ""
 
 if [ "$BUILD" = true ]; then
-  echo "Building image from local source..."
-  docker build -t "$LOCAL_IMAGE" "$(dirname "$0")"
+  echo "Building image from local source (no cache)..."
+  docker build --no-cache -t "$LOCAL_IMAGE" "$(dirname "$0")"
   IMAGE="$LOCAL_IMAGE"
 else
   echo "Configuring Docker for Artifact Registry..."

--- a/applications/foldrun/src/foldrun-viewer/templates/index.html
+++ b/applications/foldrun/src/foldrun-viewer/templates/index.html
@@ -72,6 +72,33 @@
 
         .refresh-btn:hover { background: #e8f0fe; }
 
+        .quality-badge {
+            display: inline-block;
+            font-size: 0.72rem;
+            font-weight: 600;
+            padding: 2px 7px;
+            border-radius: 10px;
+            white-space: nowrap;
+        }
+        .quality-very-high { background: #d2e3fc; color: #0053D6; }
+        .quality-high      { background: #d3f0fb; color: #0077A8; }
+        .quality-low       { background: #fef7d0; color: #8a6d00; }
+        .quality-very-low  { background: #fde8e0; color: #b83200; }
+        .quality-loading   { color: #aaa; font-size: 0.72rem; }
+
+        .load-more-btn {
+            display: block;
+            margin: 16px auto 0;
+            background: none;
+            border: 1px solid #dadce0;
+            border-radius: 8px;
+            padding: 6px 24px;
+            color: #444;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+        .load-more-btn:hover { background: #f1f3f4; }
+
         .filter-row {
             display: flex;
             gap: 10px;
@@ -361,7 +388,15 @@
 
     <script>
         let allJobs = [];
+        let nextPageToken = '';
         let refreshTimer = null;
+
+        const QUALITY_META = {
+            very_high_confidence: { label: 'Very High', cls: 'quality-very-high' },
+            high_confidence:      { label: 'High',      cls: 'quality-high'      },
+            low_confidence:       { label: 'Low',        cls: 'quality-low'       },
+            very_low_confidence:  { label: 'Very Low',  cls: 'quality-very-low'  },
+        };
 
         const MODEL_LABELS = {
             alphafold2: 'AlphaFold2',
@@ -433,14 +468,28 @@
                     actionBtn = `<a class="view-btn disabled" href="#">View</a>`;
                 }
 
+                const qualityEl = j.has_analysis
+                    ? `<span class="quality-loading" id="quality-${j.job_id}">…</span>`
+                    : `<span></span>`;
+
                 return `<div class="job-row" id="row-${j.job_id}">
                     <span class="model-badge ${badge}">${label}</span>
                     <span class="state-chip ${sm.cls}">${sm.label}</span>
+                    ${qualityEl}
                     <span class="job-name" title="${j.job_id}">${j.display_name || j.job_id}</span>
                     <span class="job-time">${relativeTime(j.create_time)}</span>
                     ${actionBtn}
                 </div>`;
             }).join('');
+
+            // Load more button
+            if (nextPageToken) {
+                container.insertAdjacentHTML('beforeend',
+                    `<button class="load-more-btn" onclick="loadMore()">Load more</button>`);
+            }
+
+            // Lazy-load quality badges for analyzed jobs
+            filtered.filter(j => j.has_analysis).forEach(j => loadQuality(j.job_id));
         }
 
         async function analyzeJob(jobId, modelType, btn) {
@@ -472,11 +521,42 @@
             }
         }
 
+        async function loadQuality(jobId) {
+            try {
+                const resp = await fetch(`/api/quality/${encodeURIComponent(jobId)}`);
+                if (!resp.ok) return;
+                const data = await resp.json();
+                const el = document.getElementById(`quality-${jobId}`);
+                if (!el) return;
+                const meta = QUALITY_META[data.quality_assessment];
+                if (meta) {
+                    el.className = `quality-badge ${meta.cls}`;
+                    el.textContent = meta.label;
+                } else {
+                    el.textContent = '';
+                }
+            } catch (_) { /* badge stays blank on error */ }
+        }
+
+        async function loadMore() {
+            if (!nextPageToken) return;
+            try {
+                const resp = await fetch(`/api/jobs?page_token=${encodeURIComponent(nextPageToken)}`);
+                const data = await resp.json();
+                allJobs = allJobs.concat(data.jobs || []);
+                nextPageToken = data.next_page_token || '';
+                renderJobs();
+            } catch (err) {
+                console.error('Load more failed:', err);
+            }
+        }
+
         async function loadJobs() {
             document.getElementById('jobs-container').innerHTML =
                 '<div class="jobs-loading">Loading recent jobs…</div>';
 
             clearTimeout(refreshTimer);
+            nextPageToken = '';
 
             try {
                 const resp = await fetch('/api/jobs');
@@ -489,16 +569,17 @@
                 }
 
                 allJobs = data.jobs || [];
+                nextPageToken = data.next_page_token || '';
                 renderJobs();
 
-                // Auto-refresh while any job is running
+                // Auto-refresh while any job is running — 60s to reduce GCS polling load
                 const hasRunning = allJobs.some(j =>
                     j.state === 'PIPELINE_STATE_RUNNING' ||
                     j.state === 'PIPELINE_STATE_PENDING' ||
                     j.state === 'PIPELINE_STATE_QUEUED'
                 );
                 if (hasRunning) {
-                    refreshTimer = setTimeout(loadJobs, 30000);
+                    refreshTimer = setTimeout(loadJobs, 60000);
                 }
             } catch (err) {
                 document.getElementById('jobs-container').innerHTML =

--- a/applications/foldrun/src/foldrun-viewer/templates/index.html
+++ b/applications/foldrun/src/foldrun-viewer/templates/index.html
@@ -133,16 +133,23 @@
 
         .job-row {
             display: grid;
-            grid-template-columns: 82px 90px 78px 1fr 64px 150px;
+            grid-template-columns: 90px 90px 76px 1fr max-content auto;
             align-items: center;
-            gap: 10px;
-            padding: 12px 18px;
+            gap: 12px;
+            padding: 11px 18px;
             border-bottom: 1px solid #f1f3f4;
             transition: background 0.15s;
         }
 
         .job-row:last-child { border-bottom: none; }
         .job-row:hover { background: #f8f9fa; }
+
+        .job-actions {
+            display: flex;
+            gap: 6px;
+            justify-content: flex-end;
+            align-items: center;
+        }
 
         .model-badge {
             font-size: 0.72rem;
@@ -480,7 +487,7 @@
                     ${qualityEl}
                     <span class="job-name" title="${j.job_id}">${j.display_name || j.job_id}</span>
                     <span class="job-time">${relativeTime(j.create_time)}</span>
-                    ${actionBtn}
+                    <div class="job-actions">${actionBtn}</div>
                 </div>`;
             }).join('');
 

--- a/applications/foldrun/src/foldrun-viewer/templates/index.html
+++ b/applications/foldrun/src/foldrun-viewer/templates/index.html
@@ -132,10 +132,11 @@
         .jobs-error { color: #c5221f; }
 
         .job-row {
-            display: flex;
+            display: grid;
+            grid-template-columns: 82px 90px 78px 1fr 64px 150px;
             align-items: center;
-            gap: 12px;
-            padding: 14px 18px;
+            gap: 10px;
+            padding: 12px 18px;
             border-bottom: 1px solid #f1f3f4;
             transition: background 0.15s;
         }
@@ -468,7 +469,8 @@
                     actionBtn = `<a class="view-btn disabled" href="#">View</a>`;
                 }
 
-                const qualityEl = j.has_analysis
+                const showQuality = j.has_analysis && j.state === 'PIPELINE_STATE_SUCCEEDED';
+                const qualityEl = showQuality
                     ? `<span class="quality-loading" id="quality-${j.job_id}">…</span>`
                     : `<span></span>`;
 
@@ -488,8 +490,10 @@
                     `<button class="load-more-btn" onclick="loadMore()">Load more</button>`);
             }
 
-            // Lazy-load quality badges for analyzed jobs
-            filtered.filter(j => j.has_analysis).forEach(j => loadQuality(j.job_id));
+            // Lazy-load quality badges — succeeded jobs with analysis only
+            filtered
+                .filter(j => j.has_analysis && j.state === 'PIPELINE_STATE_SUCCEEDED')
+                .forEach(j => loadQuality(j.job_id));
         }
 
         async function analyzeJob(jobId, modelType, btn) {


### PR DESCRIPTION
## Changes

### Quality badge (lazy-loaded)
A color-coded quality pill appears per row for analyzed jobs, loaded asynchronously after the list renders — page load is unaffected.

| Badge | pLDDT | Color |
|---|---|---|
| Very High | ≥90 | Blue |
| High | 70–90 | Teal |
| Low | 50–70 | Yellow |
| Very Low | <50 | Orange |

Uses the same pLDDT color scale already shown in the 3D viewer. No numbers in the index — just the qualitative label.

**New endpoint:** `GET /api/quality/<job_id>` reads `analysis/summary.json` from GCS and returns `quality_assessment` + `best_model_plddt`. Returns 404 if no summary yet. Called once per analyzed row after initial render.

### Pagination
`/api/jobs` now returns 20 jobs per page (was 50) plus a `next_page_token`. A **Load more** button appears at the bottom when more results exist. Reduces the Vertex AI API response size and the number of quality fetches on first load.

### Slower auto-refresh
Auto-refresh interval during active jobs: **30s → 60s**. Halves the GCS polling load while still being responsive enough for monitoring running jobs.

## Test plan
- [ ] Load job index — confirm list appears immediately, badges trickle in per row
- [ ] Jobs with analysis show correct quality badge color and label
- [ ] Jobs without analysis show no badge (blank space)
- [ ] Load more button appears when >20 jobs exist; loads next page and appends rows
- [ ] Auto-refresh fires at 60s (not 30s) when a job is running
- [ ] `/api/quality/<job_id>` returns 404 for jobs with no analysis