### PR TITLE
chore: migrate to pre-defined IAM roles for viewer running jobs

### DIFF
--- a/applications/foldrun/terraform/viewer.tf
+++ b/applications/foldrun/terraform/viewer.tf
@@ -48,17 +48,6 @@ resource "google_project_iam_member" "foldrun_viewer_aiplatform" {
   member  = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 
-# Minimal custom role: only run.jobs.run + run.jobs.runWithOverrides.
-# roles/run.invoker only has run.jobs.run; roles/run.developer is too broad
-# (includes delete, update, create). This custom role is the least privilege needed.
-resource "google_project_iam_custom_role" "foldrun_job_runner" {
-  role_id     = "foldrun_job_runner"
-  title       = "FoldRun Job Runner"
-  description = "Allows triggering Cloud Run Jobs with overrides from the FoldRun viewer"
-  permissions = ["run.jobs.run", "run.jobs.runWithOverrides"]
-  project     = var.project_id
-}
-
 # Allow the viewer SA to act as the analysis SA when triggering Cloud Run jobs.
 # The Cloud Run v2 :run endpoint requires actAs on the job's service account
 # in addition to run.jobs.run on the job resource.
@@ -69,27 +58,16 @@ resource "google_service_account_iam_member" "foldrun_viewer_actas_analysis" {
 }
 
 # Allow the viewer to trigger the Cloud Run analysis jobs from the UI
-resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_af2_analysis" {
+resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_analysis" {
+  for_each = toset([
+    google_cloud_run_v2_job.af2_analysis_job.name,
+    google_cloud_run_v2_job.of3_analysis_job.name,
+    google_cloud_run_v2_job.boltz2_analysis_job.name
+  ])
   project  = var.project_id
   location = var.region
-  name     = google_cloud_run_v2_job.af2_analysis_job.name
-  role     = "projects/${var.project_id}/roles/foldrun_job_runner"
-  member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
-}
-
-resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_of3_analysis" {
-  project  = var.project_id
-  location = var.region
-  name     = google_cloud_run_v2_job.of3_analysis_job.name
-  role     = "projects/${var.project_id}/roles/foldrun_job_runner"
-  member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
-}
-
-resource "google_cloud_run_v2_job_iam_member" "foldrun_viewer_run_boltz2_analysis" {
-  project  = var.project_id
-  location = var.region
-  name     = google_cloud_run_v2_job.boltz2_analysis_job.name
-  role     = "projects/${var.project_id}/roles/foldrun_job_runner"
+  name     = each.value
+  role     = "roles/run.jobsExecutorWithOverrides"
   member   = "serviceAccount:${google_service_account.foldrun_viewer.email}"
 }
 


### PR DESCRIPTION
Simplify to predefined role for viewer triggering Cloud Run jobs