### PR TITLE
fix(deploy): skip interactive db menu when --db target is specified

### DIFF
--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -369,10 +369,14 @@ if $run_data; then
         FORCE_ARG="--force"
     fi
 
-    # If GCS_SOURCE_BUCKET is already set (e.g., from env), use it directly
+    # If GCS_SOURCE_BUCKET is already set (e.g., from env), use it directly.
+    # If a specific --db target is given, skip the menu and download from internet.
     if [[ -n "${GCS_SOURCE_BUCKET:-}" ]]; then
         echo "Restoring databases from GCS: gs://${GCS_SOURCE_BUCKET}/"
         uv run python scripts/setup_data.py $DB_ARG $FORCE_ARG --source-bucket "$GCS_SOURCE_BUCKET"
+    elif [[ -n "$DB_NAME" ]]; then
+        echo "Downloading $DB_NAME from internet..."
+        uv run python scripts/setup_data.py $DB_ARG $FORCE_ARG
     else
         echo ""
         echo "================================================================================"


### PR DESCRIPTION
## Problem

Running `./deploy-all.sh <project> --steps data --db of3_params --force` drops into the interactive 3-option menu asking how to populate databases, even though the intent is unambiguous: re-download that specific database from the internet.

The menu is shown whenever `GCS_SOURCE_BUCKET` is not set, regardless of whether `--db` was passed.

## Fix

Add an early exit for the targeted-db case — if `--db` is specified, skip the menu and go straight to the internet download:

```bash
elif [[ -n "$DB_NAME" ]]; then
    echo "Downloading $DB_NAME from internet..."
    uv run python scripts/setup_data.py $DB_ARG $FORCE_ARG
```

`--db` + `--force` now works non-interactively as intended.