### PR TITLE
fix(deploy): export OF3/Boltz2 image vars and guard against uninterpolated project ID

### DIFF
--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -162,7 +162,7 @@ PROJECT_ID=${POSITIONAL_ARGS[0]:-$(gcloud config get-value project)}
 
 if [[ "$PROJECT_ID" == "{self.config.project_id}" ]]; then
     echo "ERROR: You passed the literal string '{self.config.project_id}' as the project ID."
-    echo "Please replace it with your actual GCP project ID (e.g., losiern-foldrun7)."
+    echo "Please replace it with your actual GCP project ID (e.g., my-gcp-project)."
     exit 1
 fi
 

--- a/applications/foldrun/deploy-all.sh
+++ b/applications/foldrun/deploy-all.sh
@@ -159,6 +159,13 @@ fi
 # Configuration
 # ==============================================================================
 PROJECT_ID=${POSITIONAL_ARGS[0]:-$(gcloud config get-value project)}
+
+if [[ "$PROJECT_ID" == "{self.config.project_id}" ]]; then
+    echo "ERROR: You passed the literal string '{self.config.project_id}' as the project ID."
+    echo "Please replace it with your actual GCP project ID (e.g., losiern-foldrun7)."
+    exit 1
+fi
+
 REGION=${POSITIONAL_ARGS[1]:-"us-central1"}
 DOWNLOAD_MODE=${DOWNLOAD_MODE:-"reduced"}
 AF2_VERSION=${AF2_VERSION:-"42719e135a62438aa651d2bc1d143626083c3703"}
@@ -359,6 +366,8 @@ if $run_data; then
     export GCS_BUCKET_NAME=$GCS_BUCKET
     export GCS_DATABASES_BUCKET=${DATABASES_BUCKET:-$GCS_BUCKET}
     export ALPHAFOLD_COMPONENTS_IMAGE=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/alphafold-components:latest
+    export OPENFOLD3_COMPONENTS_IMAGE=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/openfold3-components:latest
+    export BOLTZ2_COMPONENTS_IMAGE=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/boltz2-components:latest
     export DOWNLOAD_MODE
     DB_ARG=""
     if [[ -n "$DB_NAME" ]]; then


### PR DESCRIPTION
## Summary
- Export `OPENFOLD3_COMPONENTS_IMAGE` and `BOLTZ2_COMPONENTS_IMAGE` env vars in the `run_data` block so the OF3 model param script can reference them (needed for `--steps data --db of3_params`)
- Add a guard that exits early if the literal string `{self.config.project_id}` is passed as the project ID, preventing Python template leakage from breaking the deployment

## Test plan
- [ ] Run `./deploy-all.sh <project> --steps data --db of3_params --force` and confirm it completes without missing-var errors
- [ ] Confirm the guard fires if `{self.config.project_id}` is passed literally as the first argument