### PR TITLE
fix: viewer has_analysis detection uses gcsOutputDirectory for exact match

### DIFF
--- a/applications/foldrun/src/foldrun-viewer/app.py
+++ b/applications/foldrun/src/foldrun-viewer/app.py
@@ -449,6 +449,18 @@ def list_jobs():
             labels = pj.get("labels", {})
             resource_name = pj.get("name", "")
             job_id = resource_name.split("/")[-1]
+            # Extract exact GCS timestamp from gcsOutputDirectory (e.g.
+            # "gs://bucket/pipeline_runs/20260504_224020" → "20260504224020").
+            # This is more reliable than parsing the job ID timestamp, which can
+            # differ by 1-2 seconds from the directory name — causing false
+            # positives when multiple jobs are submitted within seconds of each other.
+            gcs_output_dir = (
+                pj.get("runtimeConfig", {}).get("gcsOutputDirectory", "")
+            )
+            gcs_ts = None
+            m = re.search(r"pipeline_runs/(\d{8})_(\d{6})", gcs_output_dir)
+            if m:
+                gcs_ts = m.group(1) + m.group(2)
             jobs.append(
                 {
                     "job_id": job_id,
@@ -458,17 +470,17 @@ def list_jobs():
                     "create_time": pj.get("createTime", ""),
                     "has_analysis": False,
                     "analysis_running": False,
+                    "_gcs_ts": gcs_ts,
                 }
             )
 
         # Single GCS scan to determine analysis state per job
         complete_ts, running_ts = _scan_analysis_state()
         for job in jobs:
-            m = re.search(r"(\d{14})$", job["job_id"])
-            if m:
-                ts = m.group(1)
+            ts = job.pop("_gcs_ts", None)
+            if ts:
                 job["has_analysis"] = ts in complete_ts
-                job["analysis_running"] = ts in running_ts
+                job["analysis_running"] = ts in running_ts and not job["has_analysis"]
 
         return jsonify({
             "jobs": jobs,


### PR DESCRIPTION
## Problem

The viewer was showing the **Analyze** button for jobs that already had completed analysis, and clicking it 403'd on the GCS overwrite.

**Root cause**: `list_jobs()` matched analysis state by parsing a timestamp from the job ID (e.g. `alphafold2-inference-pipeline-20260504224021` → `20260504224021`) and comparing against timestamps from GCS directory names (e.g. `pipeline_runs/20260504_224020/` → `20260504224020`). These differ by 1–2 seconds, so the exact match always failed and `has_analysis` was always `False`.

A ±2 second fuzzy match was considered but rejected: when the agent submits AF2 + OF3 + Boltz2 for the same protein simultaneously, all three jobs land within 1–2 seconds of each other — a fuzzy match would cause model A's analysis to satisfy model B's `has_analysis` check.

## Fix

The Vertex AI `pipelineJobs.list` API returns `runtimeConfig.gcsOutputDirectory` for each job. Extract the GCS timestamp directly from that field and do an exact match:

```python
m = re.search(r"pipeline_runs/(\d{8})_(\d{6})", gcs_output_dir)
if m:
    gcs_ts = m.group(1) + m.group(2)  # e.g. "20260504224020" — exact match
```

## Test plan

- [ ] Jobs with `summary.json` show **View** (not Analyze)
- [ ] Jobs without analysis show **Analyze**
- [ ] Three jobs submitted simultaneously for the same protein each reflect their own analysis state independently