### PR TITLE
fix(model-garden): handle text/* inline_data from GE pre-extracted uploads (.docx, .txt)

### DIFF
--- a/applications/pharma-on-gemini-enterprise/model-garden-on-gemini-enterprise/model_garden_agent/agent.py
+++ b/applications/pharma-on-gemini-enterprise/model-garden-on-gemini-enterprise/model_garden_agent/agent.py
@@ -15,10 +15,40 @@
 import os
 import re
 
+from anthropic import types as _anthropic_types
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.agents.llm_agent import Agent
+from google.adk.models import anthropic_llm as _anthropic_llm
 from google.adk.models.llm_request import LlmRequest
 from google.genai import types
+
+
+# Gemini Enterprise pre-extracts some uploads (notably .docx, .txt) and ships
+# the result inline as `Blob(mime_type='text/plain', data=...)`. ADK's
+# Anthropic adapter has no branch for text/* inline_data and raises
+# `NotImplementedError`, which GE renders as a silent "no response." Wrap the
+# adapter's per-part translator to map any text/* Blob to a TextBlockParam.
+# The function is named `part_to_message_block` in ADK ≤1.32 and
+# `_part_to_message_block` in ADK ≥1.33 — wrap whichever is present.
+for _attr in ('part_to_message_block', '_part_to_message_block'):
+  _orig = getattr(_anthropic_llm, _attr, None)
+  if _orig is None:
+    continue
+
+  def _make_wrapper(orig):
+    def _wrapper(part, *args, **kwargs):
+      blob = getattr(part, 'inline_data', None)
+      mime = getattr(blob, 'mime_type', None) if blob else None
+      if mime and mime.startswith('text/'):
+        return _anthropic_types.TextBlockParam(
+            type='text',
+            text=blob.data.decode('utf-8', errors='replace'),
+        )
+      return orig(part, *args, **kwargs)
+    return _wrapper
+
+  setattr(_anthropic_llm, _attr, _make_wrapper(_orig))
+
 
 # === OPTIONAL: Web Grounding for Enterprise — uncomment block (1) imports
 # below, (2) the helper + tool function further down, and (3) the
@@ -72,6 +102,25 @@ def _is_claude_inline(mime: str | None) -> bool:
   if not mime:
     return False
   return any(mime.startswith(prefix) for prefix in _CLAUDE_INLINE_MIMES)
+
+
+async def _resolve_marker(
+    callback_context: CallbackContext,
+    name: str,
+    artifact_keys: set[str],
+):
+  """Load the artifact a GE filename marker refers to.
+
+  Falls back to the empty-string key — GE has been observed to store some
+  binary uploads under '' instead of the filename. Only useful for the
+  single-file case; if multiple uploads collide on '' there's nothing we
+  can do downstream.
+  """
+  if name in artifact_keys:
+    return await callback_context.load_artifact(name)
+  if '' in artifact_keys:
+    return await callback_context.load_artifact('')
+  return None
 
 
 # === OPTIONAL: Web search — uncomment to enable. ===
@@ -266,9 +315,11 @@ async def _inject_uploaded_artifacts(
         continue
       for match in _FILE_MARKER_RE.finditer(part.text):
         name = match.group('name').strip()
-        if name in injected or name not in artifact_keys:
+        if name in injected:
           continue
-        artifact_part = await callback_context.load_artifact(name)
+        artifact_part = await _resolve_marker(
+            callback_context, name, artifact_keys
+        )
         if artifact_part is None or artifact_part.inline_data is None:
           continue
         new_part = types.Part(


### PR DESCRIPTION
## Summary

- Patches ADK's third-party-model adapter at module-load time to translate `text/*` inline_data Blobs into plain text content blocks, fixing silent "no response" turns when users upload `.docx` (and similar pre-extracted-by-GE formats) in Gemini Enterprise.
- Adds a defensive tolerant-fallback for the GE quirk where some binary uploads land under the empty-string artifact key instead of the filename.

## Root cause

Gemini Enterprise pre-extracts certain uploads (notably `.docx`, `.txt`) on its end and ships the result to custom Agent Engine agents as `Part(inline_data=Blob(mime_type='text/plain', data=...))` rather than as raw bytes or via the `ArtifactService`.

The ADK adapter ADK uses for non-Gemini planners (`google.adk.models` — see the import in the diff) has explicit per-part branches for `image/*`, `application/pdf`, function call/response, and executable code, but no branch for `text/*` inline_data — so it raises `NotImplementedError: Not supported yet: ... inline_data=Blob(mime_type='text/plain', ...)`. The error propagates back to GE, which silently renders an empty turn with no error visible to the user.

The upstream API itself accepts plain-text content blocks fine; the gap is purely in ADK's translation layer.

## Why a module-load patch rather than a callback-layer fix

A `before_model_callback`-layer normalization (rewriting text/* `inline_data` Parts into `Part(text=...)`) was tried first but didn't take effect in Agent Engine. In production, `content.parts` is a protobuf `RepeatedCompositeFieldContainer`; item-index assignment silently fails and ADK dispatches the original unmodified request, and slice-assigned rebuilds also did not propagate cleanly to the model adapter in observed traces.

Patching at the per-part translator is the actual point of failure — it works regardless of where in the request lifecycle the offending Part appears.

## Test plan

- [x] Local check: call the patched per-part translator on `Blob(mime_type='text/plain')`, `Blob(mime_type='application/pdf')`, and a native `text=` Part — text/plain returns a text content block, PDF returns a document block (unchanged), native text returns a text block (unchanged).
- [x] End-to-end on `Model Garden Agent Dev` reasoning engine in peak-lettuce — uploaded a sample `.docx` via Gemini Enterprise and confirmed the agent now responds (previously hung silently).
- [ ] Reviewer should attach any `.docx` or `.txt` to the configured agent in GE and confirm a response is produced.
